### PR TITLE
Add Dauntless Shield + Fixes

### DIFF
--- a/calc/src/mechanics/gen8.ts
+++ b/calc/src/mechanics/gen8.ts
@@ -783,7 +783,7 @@ function calculateGen8(
   ) {
     atMods.push(0x2000);
     description.attackerAbility = attacker.ability;
-  } else if (attacker.hasAbility('Gorilla Tactics', 'Intrepid Sword')) {
+  } else if (attacker.hasAbility('Gorilla Tactics', 'Intrepid Sword') && move.category === 'Physical') {
     atMods.push(0x1800);
     description.attackerAbility = attacker.ability;
   }
@@ -895,6 +895,11 @@ function calculateGen8(
 
   if (defender.hasAbility('Fur Coat') && hitsPhysical) {
     dfMods.push(0x2000);
+    description.defenderAbility = defender.ability;
+  }
+
+  if (defender.hasAbility('Dauntless Shield') && hitsPhysical) {
+    dfMods.push(0x1800);
     description.defenderAbility = defender.ability;
   }
 

--- a/calc/src/mechanics/gen8.ts
+++ b/calc/src/mechanics/gen8.ts
@@ -783,7 +783,10 @@ function calculateGen8(
   ) {
     atMods.push(0x2000);
     description.attackerAbility = attacker.ability;
-  } else if (attacker.hasAbility('Gorilla Tactics', 'Intrepid Sword') && move.category === 'Physical') {
+  } else if (
+    attacker.hasAbility('Gorilla Tactics', 'Intrepid Sword') &&
+    move.category === 'Physical'
+  ) {
     atMods.push(0x1800);
     description.attackerAbility = attacker.ability;
   }


### PR DESCRIPTION
Right now, Intrepid Sword and Gorilla Tactics boost special attacks on the calc as well. This change fixes that, and also introduces Dauntless Shield to the damage calculation.