### PR TITLE
Use isMax option in constructor

### DIFF
--- a/calc/src/pokemon.ts
+++ b/calc/src/pokemon.ts
@@ -75,6 +75,7 @@ export class Pokemon {
     this.gender = options.gender || this.species.gender || 'male';
     this.ability = options.ability || this.species.ab;
     this.abilityOn = !!options.abilityOn;
+    this.isMax = options.isMax;
     this.item = options.item;
 
     this.nature = options.nature || 'Serious';


### PR DESCRIPTION
It looks like `isMax` is accepted as an option by the `Pokemon` class constructor but not actually used.

It looks like this might be an oversight!  This change sets the current value of this.isMax using that option.