### PR TITLE
Populate neutral nature stat associations

### DIFF
--- a/calc/src/data/natures.ts
+++ b/calc/src/data/natures.ts
@@ -3,14 +3,14 @@ import {Stat} from '../stats';
 
 export const NATURES: {[name: string]: [Stat?, Stat?]} = {
   Adamant: ['atk', 'spa'],
-  Bashful: [undefined, undefined],
+  Bashful: ['spa', 'spa'],
   Bold: ['def', 'atk'],
   Brave: ['atk', 'spe'],
   Calm: ['spd', 'atk'],
   Careful: ['spd', 'spa'],
-  Docile: [undefined, undefined],
+  Docile: ['def', 'def'],
   Gentle: ['spd', 'def'],
-  Hardy: [undefined, undefined],
+  Hardy: ['atk', 'atk'],
   Hasty: ['spe', 'def'],
   Impish: ['def', 'spa'],
   Jolly: ['spe', 'spa'],
@@ -21,11 +21,11 @@ export const NATURES: {[name: string]: [Stat?, Stat?]} = {
   Naive: ['spe', 'spd'],
   Naughty: ['atk', 'spd'],
   Quiet: ['spa', 'spe'],
-  Quirky: [undefined, undefined],
+  Quirky: ['spd', 'spd'],
   Rash: ['spa', 'spd'],
   Relaxed: ['def', 'spe'],
   Sassy: ['spd', 'spe'],
-  Serious: [undefined, undefined],
+  Serious: ['spe', 'spe'],
   Timid: ['spe', 'atk'],
 };
 

--- a/calc/src/stats.ts
+++ b/calc/src/stats.ts
@@ -60,7 +60,14 @@ function calcStatADV(
     const mods: [Stat?, Stat?] = nature ? NATURES[nature] : [undefined, undefined];
     let n: number;
     if (mods) {
-      n = mods[0] === stat ? 1.1 : mods[1] === stat ? 0.9 : 1;
+      n =
+        mods[0] === stat && mods[1] === stat
+          ? 1
+          : mods[0] === stat
+          ? 1.1
+          : mods[1] === stat
+          ? 0.9
+          : 1;
     } else {
       n = 1;
     }


### PR DESCRIPTION
Technically, the neutral natures are each associated with a plus and minus stat of the same value.  This would be nice to include, for lookup purposes.

I'm not 100% sure if this will break anything though, so definitely need another pair of eyes.

Associations sourced from: https://pokemondb.net/mechanics/natures