### PR TITLE
Tweaking move data for Rolling Kick

### DIFF
--- a/calc/src/data/moves.ts
+++ b/calc/src/data/moves.ts
@@ -429,7 +429,7 @@ const RBY: {
     maxPower: 100,
   },
   'Rolling Kick': {
-    bp: 70,
+    bp: 60,
     type: 'Fighting',
     category: 'Physical',
     hasSecondaryEffect: true,


### PR DESCRIPTION
Rolling kick is herein changed to be 60 base power.

Was originally listed as 70 base power, but every source on the web (and indeed, its data entry in the Pokemon Showdown files) points to it being 60 instead.