### PR TITLE
Fix Max Moves to inflict reduced damage through Protect

### DIFF
--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -87,7 +87,7 @@ export function calculateSMSS(
     return result;
   }
 
-  if (field.defenderSide.isProtected && !move.breaksProtect && !move.isZ) {
+  if (field.defenderSide.isProtected && !move.breaksProtect && !move.isZ && !attacker.isDynamaxed) {
     desc.isProtected = true;
     return result;
   }
@@ -1003,7 +1003,8 @@ export function calculateSMSS(
   }
 
   let protect = false;
-  if (field.defenderSide.isProtected && move.isZ && attacker.item && attacker.item.includes(' Z')) {
+  if (field.defenderSide.isProtected &&
+    (attacker.isDynamaxed || (move.isZ && attacker.item && attacker.item.includes(' Z')))) {
     protect = true;
     desc.isProtected = true;
   }


### PR DESCRIPTION
Using a Max Move on a protected target didn't show the right amount of damage, acting as if the max move was a regular move (i.e. 0 damage). Now it should be displaying the damage of the move divided by 4. I just used what was already coded for Z moves.