### PR TITLE
Fix display issue when using GMax formes

### DIFF
--- a/calc/src/move.ts
+++ b/calc/src/move.ts
@@ -99,6 +99,7 @@ export class Move implements State.Move {
     this.useZ = options.useZ;
     this.useMax = options.useMax;
     this.overrides = options.overrides;
+    this.species = options.species;
 
     this.bp = data.basePower;
     // These moves have a type type of these moves exists, but the damage they deal is typeless so we override it

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -764,10 +764,10 @@ function createPokemon(pokeInfo) {
 			status: CALC_STATUS[pokeInfo.find(".status").val()],
 			toxicCounter: status === 'Badly Poisoned' ? ~~pokeInfo.find(".toxic-counter").val() : 0,
 			moves: [
-				getMoveDetails(pokeInfo.find(".move1"), ability, item, isDynamaxed),
-				getMoveDetails(pokeInfo.find(".move2"), ability, item, isDynamaxed),
-				getMoveDetails(pokeInfo.find(".move3"), ability, item, isDynamaxed),
-				getMoveDetails(pokeInfo.find(".move4"), ability, item, isDynamaxed)
+				getMoveDetails(pokeInfo.find(".move1"), name, ability, item, isDynamaxed),
+				getMoveDetails(pokeInfo.find(".move2"), name, ability, item, isDynamaxed),
+				getMoveDetails(pokeInfo.find(".move3"), name, ability, item, isDynamaxed),
+				getMoveDetails(pokeInfo.find(".move4"), name, ability, item, isDynamaxed)
 			],
 			overrides: {
 				baseStats: baseStats,
@@ -783,7 +783,7 @@ function getGender(gender) {
 	return 'F';
 }
 
-function getMoveDetails(moveInfo, ability, item, useMax) {
+function getMoveDetails(moveInfo, species, ability, item, useMax) {
 	var moveName = moveInfo.find("select.move-selector").val();
 	var isZMove = gen > 6 && moveInfo.find("input.move-z").prop("checked");
 	var isCrit = moveInfo.find(".move-crit").prop("checked");
@@ -796,7 +796,7 @@ function getMoveDetails(moveInfo, ability, item, useMax) {
 	};
 	if (gen >= 4) overrides.category = moveInfo.find(".move-cat").val();
 	return new calc.Move(gen, moveName, {
-		ability: ability, item: item, useZ: isZMove, isCrit: isCrit, hits: hits,
+		ability: ability, item: item, useZ: isZMove, species: species, isCrit: isCrit, hits: hits,
 		timesUsed: timesUsed, timesUsedWithMetronome: timesUsedWithMetronome, overrides: overrides, useMax: useMax
 	});
 }


### PR DESCRIPTION
I noticed while working on adding specific EOT effects from GMax moves that those would not appear if dynamaxing a GMax forme. For example, selecting Charizard-Gmax standard set, then checking the Dynamax button, would transform Flamethrower into Max Flare instead of G-Max Wildfire.

The effect was purely visual before, so it wasn't much of an issue, but since EOT effects such as G-Max Wildfire will be added to the calculator in the near future, it would be interesting to have this behaving correctly now. This should hopefully be done now.