### PR TITLE
Tutor move damage updates

### DIFF
--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -1,4 +1,4 @@
-﻿import {Generation, AbilityName, StatName, Terrain} from '../data/interface';
+import {Generation, AbilityName, StatName, Terrain} from '../data/interface';
 import {toID} from '../util';
 import {
   getBerryResistType,
@@ -366,9 +366,10 @@ export function calculateSMSS(
     desc.moveBP = basePower;
     break;
   case 'Expanding Force':
-    basePower = move.bp * ((isGrounded(attacker, field) && field.hasTerrain('Psychic')) ? 2 : 1);
-    move.target =
-      (isGrounded(attacker, field) && field.hasTerrain('Psychic')) ? 'allAdjacentFoes' : 'normal';
+    const isTerrainBoosted =
+      isGrounded(attacker, field) && field.hasTerrain("Psychic");
+    basePower = move.bp * (isTerrainBoosted ? 1.5 : 1);
+    move.target = isTerrainBoosted ? 'allAdjacentFoes' : 'normal';
     desc.moveBP = basePower;
     break;
   case 'Misty Explosion':

--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -367,7 +367,7 @@ export function calculateSMSS(
     break;
   case 'Expanding Force':
     const isTerrainBoosted =
-      isGrounded(attacker, field) && field.hasTerrain("Psychic");
+      isGrounded(attacker, field) && field.hasTerrain('Psychic');
     basePower = move.bp * (isTerrainBoosted ? 1.5 : 1);
     move.target = isTerrainBoosted ? 'allAdjacentFoes' : 'normal';
     desc.moveBP = basePower;

--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -1,4 +1,4 @@
-import {Generation, AbilityName, StatName, Terrain} from '../data/interface';
+﻿import {Generation, AbilityName, StatName, Terrain} from '../data/interface';
 import {toID} from '../util';
 import {
   getBerryResistType,
@@ -442,7 +442,7 @@ export function calculateSMSS(
     desc.moveBP = basePower;
     break;
   case 'Terrain Pulse':
-    basePower = field.terrain ? 100 : 50;
+    basePower = move.bp * (field.terrain ? 2 : 1);
     desc.moveBP = basePower;
     break;
   case 'Fling':

--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -373,7 +373,7 @@ export function calculateSMSS(
     desc.moveBP = basePower;
     break;
   case 'Misty Explosion':
-    basePower = move.bp * (field.hasTerrain('Misty') ? 2 : 1);
+    basePower = move.bp * (field.hasTerrain('Misty') ? 1.5 : 1);
     desc.moveBP = basePower;
     break;
   case 'Rising Voltage':


### PR DESCRIPTION
## Expanding Force

Serebii and Bulbapedia disagree on the damage for expanding force.  According to Serebii, the base power is boosted by 1.5x in Psychic Terrain.  According to Bulbapedia, the terrain modifier is _replaced_ by a 2x modifier.

However, a base power increase of 1.5 results in 1.5 * 1.3 = 1.95 total damage modifier — which is very close to 2x.  Until we have clear data on exactly which is correct, I opted for 1.5 damage modifier under terrain.  This would be consistent with other moves in the Isle of Armor release, and is much closer to accurate than the calculator is returning now.

https://bulbapedia.bulbagarden.net/wiki/Expanding_Force_(move)
https://www.serebii.net/attackdex-swsh/expandingforce.shtml

## Misty Explosion

Serebii and Bulbapedia both now agree that Misty Explosion is boosted by 1.5x under terrain.

https://bulbapedia.bulbagarden.net/wiki/Misty_Explosion_(move)
https://www.serebii.net/attackdex-swsh/mistyexplosion.shtml