### PR TITLE
Fix Shell Side Arm's category

### DIFF
--- a/calc/.eslintrc
+++ b/calc/.eslintrc
@@ -2,7 +2,6 @@
   "root": true,
   "extends": "@pkmn",
   "rules": {
-    "max-len": ["error", { "code": 100, "ignoreUrls": true }],
     "no-shadow": 0,
     "jest/no-standalone-expect": "off",
     "@typescript-eslint/restrict-template-expressions": "off"

--- a/calc/.eslintrc
+++ b/calc/.eslintrc
@@ -2,6 +2,7 @@
   "root": true,
   "extends": "@pkmn",
   "rules": {
+    "max-len": ["error", { "code": 100, "ignoreUrls": true }],
     "no-shadow": 0,
     "jest/no-standalone-expect": "off",
     "@typescript-eslint/restrict-template-expressions": "off"

--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -717,14 +717,14 @@ export function calculateSMSS(
     move.category = attackSource.stats.atk > attackSource.stats.spa ? 'Physical' : 'Special';
   }
   const attackStat =
-    move.named("Shell Side Arm") &&
-    getShellSideArmCategory(attacker, defender) === "Physical"
-      ? "atk"
-      : move.named("Body Press")
-      ? "def"
-      : move.category === "Special"
-      ? "spa"
-      : "atk";
+    move.named('Shell Side Arm') &&
+    getShellSideArmCategory(attacker, defender) === 'Physical'
+      ? 'atk'
+      : move.named('Body Press')
+        ? 'def'
+        : move.category === 'Special'
+          ? 'spa'
+          : 'atk';
   desc.attackEVs =
     move.named('Foul Play')
       ? getEVDescriptionText(gen, defender, attackStat, defender.nature)

--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -33,6 +33,7 @@ import {
   getFinalDamage,
   getModifiedStat,
   getMoveEffectiveness,
+  getShellSideArmCategory,
   getWeightFactor,
   handleFixedDamageMoves,
   isGrounded,
@@ -716,9 +717,14 @@ export function calculateSMSS(
     move.category = attackSource.stats.atk > attackSource.stats.spa ? 'Physical' : 'Special';
   }
   const attackStat =
-    (move.named('Shell Side Arm') && defender.stats.def < defender.stats.spd) ? 'atk'
-    : move.named('Body Press') ? 'def'
-    : move.category === 'Special' ? 'spa' : 'atk';
+    move.named("Shell Side Arm") &&
+    getShellSideArmCategory(attacker, defender) === "Physical"
+      ? "atk"
+      : move.named("Body Press")
+      ? "def"
+      : move.category === "Special"
+      ? "spa"
+      : "atk";
   desc.attackEVs =
     move.named('Foul Play')
       ? getEVDescriptionText(gen, defender, attackStat, defender.nature)
@@ -835,7 +841,7 @@ export function calculateSMSS(
 
   let defense: number;
   const hitsPhysical = move.defensiveCategory === 'Physical' ||
-    (move.named('Shell Side Arm') && defender.stats.def < defender.stats.spd);
+    (move.named('Shell Side Arm') && getShellSideArmCategory(attacker, defender) === 'Physical');
   const defenseStat = hitsPhysical ? 'def' : 'spd';
   desc.defenseEVs = getEVDescriptionText(gen, defender, defenseStat, defender.nature);
   if (defender.boosts[defenseStat] === 0 ||

--- a/calc/src/mechanics/util.ts
+++ b/calc/src/mechanics/util.ts
@@ -358,9 +358,7 @@ export function getFinalDamage(
 }
 
 /**
- * Determines which move category Shell Side Arm should behave as. Applications
- * that consume this library may want to import this function to show users move
- * category information.
+ * Determines which move category Shell Side Arm should behave as.
  *
  * Notes:
  * 1. As far as I can tell, research hasn't been tone on whether it's the larger
@@ -369,11 +367,13 @@ export function getFinalDamage(
  * Ratio seems more likely to me, since the pokemon damage formula is
  * dependent on the ratio and not the difference of attack and defense stats.
  *
- * 2. in game, when stats are equal, category is random.  For damage, it won't
+ * 2. In game, when stats are equal, category is random.  For damage, it won't
  * matter most of the time (items like assault vest aren't included in this
- * decision though, so *may* take effect).
+ * decision though, so *may* take effect). This implementation defaults to
+ * 'Special'.
  *
- * {@link https://www.reddit.com/r/VGC/comments/hcfe4k/galarian_slowbro_shell_side_arm_breakdown/}
+ * See also:
+ * {@link https://github.com/smogon/pokemon-showdown/commit/65d2bb5d0c36b61a2577382cc30aa861521113fd#diff-706ad2c9c5d1920e4245d5debe9e3c11}
  *
  * @param source Attacking pokemon (after stat modifications)
  * @param target Target pokemon (after stat modifications)

--- a/calc/src/mechanics/util.ts
+++ b/calc/src/mechanics/util.ts
@@ -360,7 +360,7 @@ export function getFinalDamage(
 /**
  * Determines which move category Shell Side Arm should behave as.
  *
- * A simplified formula can be used here compared to what the research 
+ * A simplified formula can be used here compared to what the research
  * suggests as we do not want to implement the random tiebreak element of
  * move - instead we simply default to 'Special' and allow the user to override
  * this by manually adjusting the move's category.

--- a/calc/src/mechanics/util.ts
+++ b/calc/src/mechanics/util.ts
@@ -373,7 +373,7 @@ export function getFinalDamage(
  * 'Special'.
  *
  * See also:
- * {@link https://github.com/smogon/pokemon-showdown/commit/65d2bb5d0c36b61a2577382cc30aa861521113fd#diff-706ad2c9c5d1920e4245d5debe9e3c11}
+ * {@link https://github.com/smogon/pokemon-showdown/commit/65d2bb5d}
  *
  * @param source Attacking pokemon (after stat modifications)
  * @param target Target pokemon (after stat modifications)

--- a/calc/src/mechanics/util.ts
+++ b/calc/src/mechanics/util.ts
@@ -2,6 +2,7 @@ import {
   Generation,
   ID,
   ItemName,
+  MoveCategory,
   NatureName,
   StatName,
   StatsTable,
@@ -354,6 +355,34 @@ export function getFinalDamage(
   if (isBurned) damageAmount = Math.floor(damageAmount / 2);
   if (protect) damageAmount = pokeRound(OF32(damageAmount * 0x400) / 0x1000);
   return OF16(pokeRound(Math.max(1, OF32(damageAmount * finalMod) / 0x1000)));
+}
+
+/**
+ * Determines which move category Shell Side Arm should behave as. Applications
+ * that consume this library may want to import this function to show users move
+ * category information.
+ *
+ * Notes:
+ * 1. As far as I can tell, research hasn't been tone on whether it's the larger
+ * ratio (atk / def) or the difference (atk - def) which decides the move
+ * category.
+ * Ratio seems more likely to me, since the pokemon damage formula is
+ * dependent on the ratio and not the difference of attack and defense stats.
+ *
+ * 2. in game, when stats are equal, category is random.  For damage, it won't
+ * matter most of the time (items like assault vest aren't included in this
+ * decision though, so *may* take effect).
+ *
+ * {@link https://www.reddit.com/r/VGC/comments/hcfe4k/galarian_slowbro_shell_side_arm_breakdown/}
+ *
+ * @param source Attacking pokemon (after stat modifications)
+ * @param target Target pokemon (after stat modifications)
+ * @returns 'Physical' | 'Special'
+ */
+export function getShellSideArmCategory(source: Pokemon, target: Pokemon): MoveCategory  {
+  const physicalDamage = source.stats.atk / target.stats.def;
+  const specialDamage = source.stats.spa / target.stats.spd;
+  return physicalDamage > specialDamage ? 'Physical' : 'Special'
 }
 
 export function getWeightFactor(pokemon: Pokemon) {

--- a/calc/src/mechanics/util.ts
+++ b/calc/src/mechanics/util.ts
@@ -379,10 +379,10 @@ export function getFinalDamage(
  * @param target Target pokemon (after stat modifications)
  * @returns 'Physical' | 'Special'
  */
-export function getShellSideArmCategory(source: Pokemon, target: Pokemon): MoveCategory  {
+export function getShellSideArmCategory(source: Pokemon, target: Pokemon): MoveCategory {
   const physicalDamage = source.stats.atk / target.stats.def;
   const specialDamage = source.stats.spa / target.stats.spd;
-  return physicalDamage > specialDamage ? 'Physical' : 'Special'
+  return physicalDamage > specialDamage ? 'Physical' : 'Special';
 }
 
 export function getWeightFactor(pokemon: Pokemon) {

--- a/calc/src/mechanics/util.ts
+++ b/calc/src/mechanics/util.ts
@@ -360,17 +360,10 @@ export function getFinalDamage(
 /**
  * Determines which move category Shell Side Arm should behave as.
  *
- * Notes:
- * 1. As far as I can tell, research hasn't been tone on whether it's the larger
- * ratio (atk / def) or the difference (atk - def) which decides the move
- * category.
- * Ratio seems more likely to me, since the pokemon damage formula is
- * dependent on the ratio and not the difference of attack and defense stats.
- *
- * 2. In game, when stats are equal, category is random.  For damage, it won't
- * matter most of the time (items like assault vest aren't included in this
- * decision though, so *may* take effect). This implementation defaults to
- * 'Special'.
+ * A simplified formula can be used here compared to what the research 
+ * suggests as we do not want to implement the random tiebreak element of
+ * move - instead we simply default to 'Special' and allow the user to override
+ * this by manually adjusting the move's category.
  *
  * See also:
  * {@link https://github.com/smogon/pokemon-showdown/commit/65d2bb5d}


### PR DESCRIPTION
Based on the best science I can find, Shell Side Arm's damage category is dependant on the relative _predicted damage_ and not just the defense stats of the target pokemon.

This change matches that behaviour.  I left some notes in my implementation in case this needs following up on, once there is better info.