### PR TITLE
Add bp to Punishment for gen 4

### DIFF
--- a/calc/src/data/moves.ts
+++ b/calc/src/data/moves.ts
@@ -992,7 +992,7 @@ const DPP_PATCH: {[name: string]: DeepPartial<MoveData>} = {
   'Mud Bomb': {bp: 65, type: 'Ground', category: 'Special'},
   'Ominous Wind': {bp: 60, type: 'Ghost', category: 'Special'},
   Punishment: {
-    bp: 0,
+    bp: 60,
     type: 'Dark',
     makesContact: true,
     category: 'Physical',


### PR DESCRIPTION
calc returns 0 damage for Punishment in gen 4 due to the bp being set to 0.
Update to 60?