### PR TITLE
Support field-wide Fairy Aura, Dark Aura and Aura Break when neither Pokemon uses the ability

### DIFF
--- a/calc/src/field.ts
+++ b/calc/src/field.ts
@@ -6,6 +6,9 @@ export class Field implements State.Field {
   weather?: Weather;
   terrain?: Terrain;
   isGravity: boolean;
+  isAuraBreak?: boolean;
+  isFairyAura?: boolean;
+  isDarkAura?: boolean;
   attackerSide: Side;
   defenderSide: Side;
 
@@ -14,6 +17,9 @@ export class Field implements State.Field {
     this.terrain = field.terrain;
     this.weather = field.weather;
     this.isGravity = !!field.isGravity;
+    this.isAuraBreak = field.isAuraBreak || false;
+    this.isFairyAura = field.isFairyAura || false;
+    this.isDarkAura = field.isDarkAura || false;
 
     this.attackerSide = new Side(field.attackerSide || {});
     this.defenderSide = new Side(field.defenderSide || {});
@@ -40,6 +46,9 @@ export class Field implements State.Field {
       isGravity: this.isGravity,
       attackerSide: this.attackerSide,
       defenderSide: this.defenderSide,
+      isAuraBreak: this.isAuraBreak,
+      isDarkAura: this.isDarkAura,
+      isFairyAura: this.isFairyAura,
     });
   }
 }

--- a/calc/src/mechanics/gen56.ts
+++ b/calc/src/mechanics/gen56.ts
@@ -473,11 +473,12 @@ export function calculateBWXY(
   const aura = `${move.type} Aura`;
   const isAttackerAura = attacker.hasAbility(aura);
   const isDefenderAura = defender.hasAbility(aura);
+  const isUserAuraBreak = attacker.hasAbility('Aura Break') || defender.hasAbility('Aura Break');
   const isFieldAuraBreak = field.isAuraBreak;
   const isFieldFairyAura = field.isFairyAura && move.type === 'Fairy';
   const isFieldDarkAura = field.isDarkAura && move.type === 'Dark';
   if (isFieldFairyAura || isFieldDarkAura || isAttackerAura || isDefenderAura) {
-    if (isFieldAuraBreak || attacker.hasAbility('Aura Break') || defender.hasAbility('Aura Break')) {
+    if (isFieldAuraBreak || isUserAuraBreak) {
       bpMods.push(0x0c00);
       desc.attackerAbility = attacker.ability;
       desc.defenderAbility = defender.ability;

--- a/calc/src/mechanics/gen56.ts
+++ b/calc/src/mechanics/gen56.ts
@@ -473,8 +473,11 @@ export function calculateBWXY(
   const aura = `${move.type} Aura`;
   const isAttackerAura = attacker.hasAbility(aura);
   const isDefenderAura = defender.hasAbility(aura);
-  if (isAttackerAura || isDefenderAura) {
-    if (attacker.hasAbility('Aura Break') || defender.hasAbility('Aura Break')) {
+  const isFieldAuraBreak = field.isAuraBreak;
+  const isFieldFairyAura = field.isFairyAura && move.type === 'Fairy';
+  const isFieldDarkAura = field.isDarkAura && move.type === 'Dark';
+  if (isFieldFairyAura || isFieldDarkAura || isAttackerAura || isDefenderAura) {
+    if (isFieldAuraBreak || attacker.hasAbility('Aura Break') || defender.hasAbility('Aura Break')) {
       bpMods.push(0x0c00);
       desc.attackerAbility = attacker.ability;
       desc.defenderAbility = defender.ability;

--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -520,8 +520,11 @@ export function calculateSMSS(
   const aura = `${move.type} Aura`;
   const isAttackerAura = attacker.hasAbility(aura);
   const isDefenderAura = defender.hasAbility(aura);
-  const auraActive = isAttackerAura || isDefenderAura;
-  const auraBreak = attacker.hasAbility('Aura Break') || defender.hasAbility('Aura Break');
+  const isFieldAuraBreak = field.isAuraBreak;
+  const isFieldFairyAura = field.isFairyAura && move.type === 'Fairy';
+  const isFieldDarkAura = field.isDarkAura && move.type === 'Dark';
+  const auraActive = isAttackerAura || isDefenderAura || isFieldFairyAura || isFieldDarkAura;
+  const auraBreak = isFieldAuraBreak || attacker.hasAbility('Aura Break') || defender.hasAbility('Aura Break');
   if (auraActive && auraBreak) {
     bpMods.push(0x0c00);
     desc.attackerAbility = attacker.ability;

--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -520,11 +520,12 @@ export function calculateSMSS(
   const aura = `${move.type} Aura`;
   const isAttackerAura = attacker.hasAbility(aura);
   const isDefenderAura = defender.hasAbility(aura);
+  const isUserAuraBreak = attacker.hasAbility('Aura Break') || defender.hasAbility('Aura Break');
   const isFieldAuraBreak = field.isAuraBreak;
   const isFieldFairyAura = field.isFairyAura && move.type === 'Fairy';
   const isFieldDarkAura = field.isDarkAura && move.type === 'Dark';
   const auraActive = isAttackerAura || isDefenderAura || isFieldFairyAura || isFieldDarkAura;
-  const auraBreak = isFieldAuraBreak || attacker.hasAbility('Aura Break') || defender.hasAbility('Aura Break');
+  const auraBreak = isFieldAuraBreak || isUserAuraBreak;
   if (auraActive && auraBreak) {
     bpMods.push(0x0c00);
     desc.attackerAbility = attacker.ability;

--- a/calc/src/state.ts
+++ b/calc/src/state.ts
@@ -36,6 +36,9 @@ export namespace State {
     weather?: I.Weather;
     terrain?: I.Terrain;
     isGravity?: boolean;
+    isAuraBreak?: boolean;
+    isFairyAura?: boolean;
+    isDarkAura?: boolean;
     attackerSide: Side;
     defenderSide: Side;
   }


### PR DESCRIPTION
Fairy Aura, Dark Aura, and Aura Break currently rely on one of the two Pokemon involved in the calc using the appropriate ability. To better support partners carrying these abilities in VGC/doubles, these three ability effects have been added to the Field class.

The missing support for this functionality was brought to me by @jbmagier and I arrived at a solution following some discussion between us.

This PR simply implements the under the hood functionality for use in the @smogon/calc module, and does not implement the front end support. This functionality can be seen in use on the Pikalytics Damage Calc in the screenshots below:

![Screen Shot 2021-02-06 at 11 00 30 AM](https://user-images.githubusercontent.com/2390265/107127384-99bc2b00-686a-11eb-9e64-acac350c8840.png)
![Screen Shot 2021-02-06 at 11 00 14 AM](https://user-images.githubusercontent.com/2390265/107127387-9a54c180-686a-11eb-9099-d3e5e5ab7ef2.png)
