### PR TITLE
Fix Reversal and Flail power calculation for Gen 4

### DIFF
--- a/calc/src/mechanics/gen4.ts
+++ b/calc/src/mechanics/gen4.ts
@@ -162,8 +162,8 @@ export function calculateDPP(
     break;
   case 'Flail':
   case 'Reversal':
-    const p = Math.floor((48 * attacker.curHP()) / attacker.maxHP());
-    basePower = p <= 1 ? 200 : p <= 4 ? 150 : p <= 9 ? 100 : p <= 16 ? 80 : p <= 32 ? 40 : 20;
+    const p = Math.floor((64 * attacker.curHP()) / attacker.maxHP());
+    basePower = p <= 1 ? 200 : p <= 5 ? 150 : p <= 12 ? 100 : p <= 21 ? 80 : p <= 42 ? 40 : 20;
     desc.moveBP = basePower;
     break;
   case 'Fling':


### PR DESCRIPTION
After investigation in Generation 4 speedrunning (thanks minnow), it appears that the thresholds for Gen 4 are wrong when calculating the power of Flail and Reversal.

The calculation is correct for Gen 5+, though.