### PR TITLE
Fix Rivalry boost

### DIFF
--- a/calc/src/mechanics/gen56.ts
+++ b/calc/src/mechanics/gen56.ts
@@ -399,7 +399,7 @@ export function calculateBWXY(
       bpMods.push(0x1400);
       desc.rivalry = 'buffed';
     } else {
-      bpMods.push(0xccd);
+      bpMods.push(0xc00);
       desc.rivalry = 'nerfed';
     }
     desc.attackerAbility = attacker.ability;

--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -786,10 +786,10 @@ export function calculateBPModsSMSS(
 
   if (attacker.hasAbility('Rivalry') && ![attacker.gender, defender.gender].includes('N')) {
     if (attacker.gender === defender.gender) {
-      bpMods.push(0xC00);
+      bpMods.push(0x1400);
       desc.rivalry = 'buffed';
     } else {
-      bpMods.push(0xCCD);
+      bpMods.push(0xC00);
       desc.rivalry = 'nerfed';
     }
     desc.attackerAbility = attacker.ability;


### PR DESCRIPTION
https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/page-8#post-8199267 and https://www.smogon.com/bw/articles/bw_complete_damage_formula agree on 0x1400 and 0xC00. I'm not sure about gen 4 but it should be the same.