### PR TITLE
Change BP limit from 999 to 65535

### DIFF
--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -72,7 +72,7 @@ var bounds = {
 	"evs": [0, 252],
 	"ivs": [0, 31],
 	"dvs": [0, 15],
-	"move-bp": [0, 999]
+	"move-bp": [0, 65535]
 };
 for (var bounded in bounds) {
 	attachValidation(bounded, bounds[bounded][0], bounds[bounded][1]);


### PR DESCRIPTION
Being 16-bit is more cartridge accurate and also very handy for testing damage calculations with precise BP values without relying on base power modifier chaining being accurate.