### PR TITLE
Add FFA spread move modifier support

### DIFF
--- a/calc/src/data/interface.ts
+++ b/calc/src/data/interface.ts
@@ -12,7 +12,7 @@ export type SpeciesName = string & As<'SpeciesName'>;
 
 export type StatusName = 'slp' | 'psn' | 'brn' | 'frz' | 'par' | 'tox';
 
-export type GameType = 'Singles' | 'Doubles';
+export type GameType = 'Singles' | 'Doubles' | 'FFA';
 export type Terrain = 'Electric' | 'Grassy' | 'Psychic' | 'Misty';
 export type Weather =
   | 'Sand' | 'Sun' | 'Rain' | 'Hail' | 'Harsh Sunshine' | 'Heavy Rain' | 'Strong Winds';

--- a/calc/src/data/interface.ts
+++ b/calc/src/data/interface.ts
@@ -12,7 +12,7 @@ export type SpeciesName = string & As<'SpeciesName'>;
 
 export type StatusName = 'slp' | 'psn' | 'brn' | 'frz' | 'par' | 'tox';
 
-export type GameType = 'Singles' | 'Doubles' | 'FFA';
+export type GameType = 'Singles' | 'Doubles' | 'Free-For-All';
 export type Terrain = 'Electric' | 'Grassy' | 'Psychic' | 'Misty';
 export type Weather =
   | 'Sand' | 'Sun' | 'Rain' | 'Hail' | 'Harsh Sunshine' | 'Heavy Rain' | 'Strong Winds';

--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -320,7 +320,8 @@ export function calculateSMSS(
   const isSpread = field.gameType !== 'Singles' &&
      ['allAdjacent', 'allAdjacentFoes'].includes(move.target);
   if (isSpread) {
-    baseDamage = pokeRound(OF32(baseDamage * 3072) / 4096);
+    const spreadModifier = field.gameType === 'Doubles' ? 3072 : 2048;
+    baseDamage = pokeRound(OF32(baseDamage * spreadModifier) / 4096);
   }
 
   if (attacker.hasAbility('Parental Bond (Child)')) {

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -631,12 +631,15 @@
         <div aria-label="Field information" role="region">
             <fieldset class="field-info">
                 <legend align="center">Field</legend>
-                <div aria-labelledby="selectBattleFormatInstruction" class="gen-specific g3 g4 g5 g6 g7 g8" role="radiogroup" style="width: 10.6em; margin: 0 auto 5px;" title="Select the battle format.">
+                <div aria-labelledby="selectBattleFormatInstruction" class="gen-specific g3 g4 g5 g6 g7 g8" role="radiogroup" style="margin: 0 auto 5px;" title="Select the battle format.">
                     <span class="visually-hidden" id="selectBattleFormatInstruction">Select the battle format.</span>
                     <input class="visually-hidden calc-trigger" type="radio" name="format" value="Singles" id="singles-format" checked="checked" />
                     <label class="btn btn-left" for="singles-format">Singles</label>
                     <input class="visually-hidden calc-trigger" type="radio" name="format" value="Doubles" id="doubles-format" />
-                    <label class="btn btn-right" for="doubles-format">Doubles</label>
+                    <label class="btn btn-right gen-specific g3 g4 g5 g6 g7" for="doubles-format">Doubles</label>
+                    <label class="btn btn-mid gen-specific g8" for="doubles-format">Doubles</label>
+                    <input class="visually-hidden calc-trigger gen-specific g8" type="radio" name="format" value="FFA" id="ffa-format" />
+                    <label class="btn btn-right gen-specific g8" for="ffa-format" style = "width: auto;">Free-For-All</label>
                 </div>
                 <div aria-labelledby="selectTerrainInstruction" class="gen-specific g6 g7 g8" role="group" title="Select the current terrain.">
                     <span class="visually-hidden" id="selectTerrainInstruction">Select the current terrain.</span>

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -638,7 +638,7 @@
                     <input class="visually-hidden calc-trigger" type="radio" name="format" value="Doubles" id="doubles-format" />
                     <label class="btn btn-right gen-specific g3 g4 g5 g6 g7" for="doubles-format">Doubles</label>
                     <label class="btn btn-mid gen-specific g8" for="doubles-format">Doubles</label>
-                    <input class="visually-hidden calc-trigger gen-specific g8" type="radio" name="format" value="FFA" id="ffa-format" />
+                    <input class="visually-hidden calc-trigger gen-specific g8" type="radio" name="format" value="Free-For-All" id="ffa-format" />
                     <label class="btn btn-right gen-specific g8" for="ffa-format" style = "width: auto;">Free-For-All</label>
                 </div>
                 <div aria-labelledby="selectTerrainInstruction" class="gen-specific g6 g7 g8" role="group" title="Select the current terrain.">

--- a/src/randoms.template.html
+++ b/src/randoms.template.html
@@ -652,7 +652,7 @@
                     <input class="visually-hidden calc-trigger" type="radio" name="format" value="Doubles" id="doubles-format" />
                     <label class="btn btn-right gen-specific g3 g4 g5 g6 g7" for="doubles-format">Doubles</label>
                     <label class="btn btn-mid gen-specific g8" for="doubles-format">Doubles</label>
-                    <input class="visually-hidden calc-trigger gen-specific g8" type="radio" name="format" value="FFA" id="ffa-format" />
+                    <input class="visually-hidden calc-trigger gen-specific g8" type="radio" name="format" value="Free-For-All" id="ffa-format" />
                     <label class="btn btn-right gen-specific g8" for="ffa-format" style = "width: auto;">Free-For-All</label>
                 </div>
                 <div aria-labelledby="selectTerrainInstruction" class="gen-specific g6 g7 g8" role="group" title="Select the current terrain.">

--- a/src/randoms.template.html
+++ b/src/randoms.template.html
@@ -645,12 +645,15 @@
         <div aria-label="Field information" role="region">
             <fieldset class="field-info">
                 <legend align="center">Field</legend>
-                <div aria-labelledby="selectBattleFormatInstruction" class="gen-specific g3 g4 g5 g6 g7 g8" role="radiogroup" style="width: 10.6em; margin: 0 auto 5px;" title="Select the battle format.">
+                <div aria-labelledby="selectBattleFormatInstruction" class="gen-specific g3 g4 g5 g6 g7 g8" role="radiogroup" style="margin: 0 auto 5px;" title="Select the battle format.">
                     <span class="visually-hidden" id="selectBattleFormatInstruction">Select the battle format.</span>
                     <input class="visually-hidden calc-trigger" type="radio" name="format" value="Singles" id="singles-format" checked="checked" />
                     <label class="btn btn-left" for="singles-format">Singles</label>
                     <input class="visually-hidden calc-trigger" type="radio" name="format" value="Doubles" id="doubles-format" />
-                    <label class="btn btn-right" for="doubles-format">Doubles</label>
+                    <label class="btn btn-right gen-specific g3 g4 g5 g6 g7" for="doubles-format">Doubles</label>
+                    <label class="btn btn-mid gen-specific g8" for="doubles-format">Doubles</label>
+                    <input class="visually-hidden calc-trigger gen-specific g8" type="radio" name="format" value="FFA" id="ffa-format" />
+                    <label class="btn btn-right gen-specific g8" for="ffa-format" style = "width: auto;">Free-For-All</label>
                 </div>
                 <div aria-labelledby="selectTerrainInstruction" class="gen-specific g6 g7 g8" role="group" title="Select the current terrain.">
                     <span class="visually-hidden" id="selectTerrainInstruction">Select the current terrain.</span>


### PR DESCRIPTION
In order to not have doubles look rounded off in past gens, I added two labels for it, one that only displays in Gen 8 (with the btn-middle class) and one that only displays in Gens 3-7 (with the btn-right class). I am pretty sure this is not a super good way to do it (you see the extra label on page load). The proper way sounds to me like making the group of buttons into a flexbox and just applying the styling on first and last childs, but that would be a decent amount of CSS refactoring.

Screenshots:
![image](https://user-images.githubusercontent.com/23667022/116802212-c92fac00-aad6-11eb-9ba3-167ddcd58b82.png)

![image](https://user-images.githubusercontent.com/23667022/116802217-d5b40480-aad6-11eb-923b-c8231a34d8aa.png)

![image](https://user-images.githubusercontent.com/23667022/116802223-e2385d00-aad6-11eb-9764-2cee19452651.png)
