### PR TITLE
Gen 7/8: Fix -ate abilities, Reckless, and Iron Fist

### DIFF
--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -825,17 +825,20 @@ export function calculateBPModsSMSS(
   );
 
   if (!move.isZ && !move.isMax && !noTypeChange) {
-    const normal = move.hasType('Normal');
-    if (attacker.hasAbility('Aerilate') && normal ||
-      attacker.hasAbility('Galvanize') && normal ||
-      attacker.hasAbility('Pixilate') && normal ||
-      attacker.hasAbility('Refrigerate') && normal ||
-      attacker.hasAbility('Normalize')
+    // The -ate abilities already changed move typing earlier
+    const normal = new Move(gen, move.originalName).hasType('Normal');
+    if (attacker.hasAbility('Normalize') ||
+      (normal && (attacker.hasAbility('Aerilate') ||
+      attacker.hasAbility('Galvanize') ||
+      attacker.hasAbility('Pixilate') ||
+      attacker.hasAbility('Refrigerate')))
     ) {
       bpMods.push(4915);
       desc.attackerAbility = attacker.ability;
     }
-  } else if (
+  }
+  
+  if (
     (attacker.hasAbility('Reckless') && (move.recoil || move.hasCrashDamage)) ||
     (attacker.hasAbility('Iron Fist') && move.flags.punch)
   ) {

--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -131,14 +131,86 @@ export function calculateSMSS(
     (move.isCrit || (attacker.hasAbility('Merciless') && defender.hasStatus('psn', 'tox'))) &&
     move.timesUsed === 1;
 
-  move.type = getMoveTypeSMSS(
-    gen,
-    attacker,
-    defender,
-    move,
-    field,
-    desc
+  let type = move.type;
+  if (move.named('Weather Ball')) {
+    const holdingUmbrella = attacker.hasItem('Utility Umbrella');
+    type =
+      field.hasWeather('Sun', 'Harsh Sunshine') && !holdingUmbrella ? 'Fire'
+      : field.hasWeather('Rain', 'Heavy Rain') && !holdingUmbrella ? 'Water'
+      : field.hasWeather('Sand') ? 'Rock'
+      : field.hasWeather('Hail') ? 'Ice'
+      : 'Normal';
+    desc.weather = field.weather;
+    desc.moveType = type;
+  } else if (move.named('Judgment') && attacker.item && attacker.item.includes('Plate')) {
+    type = getItemBoostType(attacker.item)!;
+  } else if (move.named('Techno Blast') && attacker.item && attacker.item.includes('Drive')) {
+    type = getTechnoBlast(attacker.item)!;
+  } else if (move.named('Multi-Attack') && attacker.item && attacker.item.includes('Memory')) {
+    type = getMultiAttack(attacker.item)!;
+  } else if (move.named('Natural Gift') && attacker.item && attacker.item.includes('Berry')) {
+    const gift = getNaturalGift(gen, attacker.item)!;
+    type = gift.t;
+    desc.moveType = type;
+    desc.attackerItem = attacker.item;
+  } else if (move.named('Nature Power', 'Terrain Pulse')) {
+    type =
+      field.hasTerrain('Electric') ? 'Electric'
+      : field.hasTerrain('Grassy') ? 'Grass'
+      : field.hasTerrain('Misty') ? 'Fairy'
+      : field.hasTerrain('Psychic') ? 'Psychic'
+      : 'Normal';
+  } else if (move.named('Revelation Dance')) {
+    type = attacker.types[0];
+  } else if (move.named('Aura Wheel')) {
+    if (attacker.named('Morpeko')) {
+      type = 'Electric';
+    } else if (attacker.named('Morpeko-Hangry')) {
+      type = 'Dark';
+    }
+  }
+
+  let hasAteAbilityTypeChange = false;
+  let isAerilate = false;
+  let isPixilate = false;
+  let isRefrigerate = false;
+  let isGalvanize = false;
+  let isLiquidVoice = false;
+  let isNormalize = false;
+  const noTypeChange = move.named(
+    'Revelation Dance',
+    'Judgment',
+    'Nature Power',
+    'Techno Blast',
+    'Multi Attack',
+    'Natural Gift',
+    'Weather Ball',
+    'Terrain Pulse',
   );
+
+  if (!move.isZ && !noTypeChange) {
+    const normal = move.hasType('Normal');
+    if ((isAerilate = attacker.hasAbility('Aerilate') && normal)) {
+      type = 'Flying';
+    } else if ((isGalvanize = attacker.hasAbility('Galvanize') && normal)) {
+      type = 'Electric';
+    } else if ((isLiquidVoice = attacker.hasAbility('Liquid Voice') && !!move.flags.sound)) {
+      type = 'Water';
+    } else if ((isPixilate = attacker.hasAbility('Pixilate') && normal)) {
+      type = 'Fairy';
+    } else if ((isRefrigerate = attacker.hasAbility('Refrigerate') && normal)) {
+      type = 'Ice';
+    } else if ((isNormalize = attacker.hasAbility('Normalize'))) { // Boosts any type
+      type = 'Normal';
+    }
+    if (isGalvanize || isPixilate || isRefrigerate || isAerilate || isNormalize) {
+      desc.attackerAbility = attacker.ability;
+      hasAteAbilityTypeChange = true;
+    } else if (isLiquidVoice) {
+      desc.attackerAbility = attacker.ability;
+    }
+  }
+  move.type = type;
 
   // FIXME: this is incorrect, should be move.flags.heal, not move.drain
   if ((attacker.hasAbility('Triage') && move.drain) ||
@@ -282,6 +354,7 @@ export function calculateSMSS(
     defender,
     move,
     field,
+    hasAteAbilityTypeChange,
     desc
   );
   if (basePower === 0) {
@@ -472,99 +545,13 @@ export function calculateSMSS(
   return result;
 }
 
-export function getMoveTypeSMSS(
-  gen: Generation,
-  attacker: Pokemon,
-  defender: Pokemon,
-  move: Move,
-  field: Field,
-  desc: RawDesc
-) {
-  let type = move.type;
-  if (move.named('Weather Ball')) {
-    const holdingUmbrella = attacker.hasItem('Utility Umbrella');
-    type =
-      field.hasWeather('Sun', 'Harsh Sunshine') && !holdingUmbrella ? 'Fire'
-      : field.hasWeather('Rain', 'Heavy Rain') && !holdingUmbrella ? 'Water'
-      : field.hasWeather('Sand') ? 'Rock'
-      : field.hasWeather('Hail') ? 'Ice'
-      : 'Normal';
-    desc.weather = field.weather;
-    desc.moveType = type;
-  } else if (move.named('Judgment') && attacker.item && attacker.item.includes('Plate')) {
-    type = getItemBoostType(attacker.item)!;
-  } else if (move.named('Techno Blast') && attacker.item && attacker.item.includes('Drive')) {
-    type = getTechnoBlast(attacker.item)!;
-  } else if (move.named('Multi-Attack') && attacker.item && attacker.item.includes('Memory')) {
-    type = getMultiAttack(attacker.item)!;
-  } else if (move.named('Natural Gift') && attacker.item && attacker.item.includes('Berry')) {
-    const gift = getNaturalGift(gen, attacker.item)!;
-    type = gift.t;
-    desc.moveType = type;
-    desc.attackerItem = attacker.item;
-  } else if (move.named('Nature Power', 'Terrain Pulse')) {
-    type =
-      field.hasTerrain('Electric') ? 'Electric'
-      : field.hasTerrain('Grassy') ? 'Grass'
-      : field.hasTerrain('Misty') ? 'Fairy'
-      : field.hasTerrain('Psychic') ? 'Psychic'
-      : 'Normal';
-  } else if (move.named('Revelation Dance')) {
-    type = attacker.types[0];
-  } else if (move.named('Aura Wheel')) {
-    if (attacker.named('Morpeko')) {
-      type = 'Electric';
-    } else if (attacker.named('Morpeko-Hangry')) {
-      type = 'Dark';
-    }
-  }
-
-  let isAerilate = false;
-  let isPixilate = false;
-  let isRefrigerate = false;
-  let isGalvanize = false;
-  let isLiquidVoice = false;
-  let isNormalize = false;
-  const noTypeChange = move.named(
-    'Revelation Dance',
-    'Judgment',
-    'Nature Power',
-    'Techno Blast',
-    'Multi Attack',
-    'Natural Gift',
-    'Weather Ball',
-    'Terrain Pulse',
-  );
-
-  if (!move.isZ && !noTypeChange) {
-    const normal = move.hasType('Normal');
-    if ((isAerilate = attacker.hasAbility('Aerilate') && normal)) {
-      type = 'Flying';
-    } else if ((isGalvanize = attacker.hasAbility('Galvanize') && normal)) {
-      type = 'Electric';
-    } else if ((isLiquidVoice = attacker.hasAbility('Liquid Voice') && !!move.flags.sound)) {
-      type = 'Water';
-    } else if ((isPixilate = attacker.hasAbility('Pixilate') && normal)) {
-      type = 'Fairy';
-    } else if ((isRefrigerate = attacker.hasAbility('Refrigerate') && normal)) {
-      type = 'Ice';
-    } else if ((isNormalize = attacker.hasAbility('Normalize'))) { // Boosts any type
-      type = 'Normal';
-    }
-    if (isGalvanize || isLiquidVoice || isPixilate || isRefrigerate || isAerilate || isNormalize) {
-      desc.attackerAbility = attacker.ability;
-    }
-  }
-
-  return type;
-}
-
 export function calculateBasePowerSMSS(
   gen: Generation,
   attacker: Pokemon,
   defender: Pokemon,
   move: Move,
   field: Field,
+  hasAteAbilityTypeChange: boolean,
   desc: RawDesc
 ) {
   const turnOrder = attacker.stats.spe > defender.stats.spe ? 'first' : 'last';
@@ -743,6 +730,7 @@ export function calculateBasePowerSMSS(
     field,
     desc,
     basePower,
+    hasAteAbilityTypeChange,
     turnOrder
   );
   basePower = OF16(Math.max(1, pokeRound((basePower * chainMods(bpMods)) / 4096)));
@@ -757,6 +745,7 @@ export function calculateBPModsSMSS(
   field: Field,
   desc: RawDesc,
   basePower: number,
+  hasAteAbilityTypeChange: boolean,
   turnOrder: string
 ) {
   let resistedKnockOffDamage =
@@ -824,20 +813,11 @@ export function calculateBPModsSMSS(
     'Terrain Pulse',
   );
 
-  if (!move.isZ && !move.isMax && !noTypeChange) {
-    // The -ate abilities already changed move typing earlier
-    const normal = new Move(gen, move.originalName).hasType('Normal');
-    if (attacker.hasAbility('Normalize') ||
-      (normal && (attacker.hasAbility('Aerilate') ||
-      attacker.hasAbility('Galvanize') ||
-      attacker.hasAbility('Pixilate') ||
-      attacker.hasAbility('Refrigerate')))
-    ) {
-      bpMods.push(4915);
-      desc.attackerAbility = attacker.ability;
-    }
+  if (!move.isZ && !move.isMax && !noTypeChange && hasAteAbilityTypeChange) {
+    // The -ate abilities already changed move typing earlier, so desc is already set
+    bpMods.push(4915);
   }
-  
+
   if (
     (attacker.hasAbility('Reckless') && (move.recoil || move.hasCrashDamage)) ||
     (attacker.hasAbility('Iron Fist') && move.flags.punch)

--- a/calc/src/test/calc.test.ts
+++ b/calc/src/test/calc.test.ts
@@ -801,6 +801,16 @@ describe('calc', () => {
         );
       });
 
+      test('-ate Abilities', () => {
+        const sylveon = Pokemon('Sylveon', {ability: 'Pixilate', evs: {spa: 252}});
+        const silvally = Pokemon('Silvally');
+        const hypervoice = Move('Hyper Voice');
+        const result = calculate(sylveon, silvally, hypervoice);
+        expect(result.desc()).toBe(
+          '252 SpA Pixilate Sylveon Hyper Voice vs. 0 HP / 0 SpD Silvally: 165-195 (49.8 - 58.9%) -- 99.6% chance to 2HKO'
+        );
+      });
+
       test('% chance to OHKO', () => {
         const abomasnow = Pokemon('Abomasnow', {
           level: 55,


### PR DESCRIPTION
Something about https://github.com/smogon/damage-calc/pull/439 changed how -ate abilities worked with typing; currently, whenever the move enters the function, it is already Fairy / Electric / etc. and so the check for "if you're a Normal-type move" doesn't work. To fix this, I create a new move object to check if the original move really is Normal. I'm not super sure why this worked before; probably the correct solution is to set a flag or something.

Splitting off the if statement on Reckless and Iron Fist fixes that part.

Fixes:
https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/post-8841109
https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/post-8841181