### PR TITLE
Improve base power modifiers

### DIFF
--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -692,7 +692,7 @@ export function calculateBasePowerSMSS(
     basePower = move.hits === 2 ? 30 : move.hits === 3 ? 40 : 20;
     desc.moveBP = basePower;
     break;
-    // Triple Kick's damage doubles after each consecutive hit (10, 20, 30), this is a hack
+  // Triple Kick's damage doubles after each consecutive hit (10, 20, 30), this is a hack
   case 'Triple Kick':
     basePower = move.hits === 2 ? 15 : move.hits === 3 ? 30 : 10;
     desc.moveBP = basePower;

--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -623,10 +623,6 @@ export function calculateBasePowerSMSS(
     basePower = move.bp * (attacker.hasItem('Flying Gem') || !attacker.item ? 2 : 1);
     desc.moveBP = basePower;
     break;
-  case 'Grav Apple':
-    basePower = move.bp * (field.isGravity ? 1.5 : 1);
-    desc.moveBP = basePower;
-    break;
   case 'Assurance':
     basePower = move.bp * (defender.hasAbility('Parental Bond (Child)') ? 2 : 1);
     // NOTE: desc.attackerAbility = 'Parental Bond' will already reflect this boost
@@ -648,6 +644,10 @@ export function calculateBasePowerSMSS(
     break;
   case 'Terrain Pulse':
     basePower = move.bp * (isGrounded(attacker, field) && field.terrain ? 2 : 1);
+    desc.moveBP = basePower;
+    break;
+  case 'Rising Voltage':
+    basePower = move.bp * ((isGrounded(defender, field) && field.hasTerrain('Electric')) ? 2 : 1);
     desc.moveBP = basePower;
     break;
   case 'Fling':
@@ -696,10 +696,6 @@ export function calculateBasePowerSMSS(
   // Triple Kick's damage doubles after each consecutive hit (10, 20, 30), this is a hack
   case 'Triple Kick':
     basePower = move.hits === 2 ? 15 : move.hits === 3 ? 30 : 10;
-    desc.moveBP = basePower;
-    break;
-  case 'Lash Out':
-    basePower = move.bp * (countBoosts(gen, attacker.boosts) < 0 ? 2 : 1);
     desc.moveBP = basePower;
     break;
   case 'Crush Grip':
@@ -775,13 +771,14 @@ export function calculateBPModsSMSS(
   if ((move.named('Facade') && attacker.hasStatus('brn', 'par', 'psn', 'tox')) ||
     (move.named('Brine') && defender.curHP() <= defender.maxHP() / 2) ||
     (move.named('Venoshock') && defender.hasStatus('psn', 'tox')) ||
-    (move.named('Rising Voltage') && isGrounded(defender, field) && field.hasTerrain('Electric'))
+    (move.named('Lash Out') && (countBoosts(gen, attacker.boosts) < 0))
   ) {
     bpMods.push(8192);
     desc.moveBP = basePower * 2;
   } else if ((move.named('Knock Off') && !resistedKnockOffDamage) ||
     (move.named('Expanding Force') && isGrounded(attacker, field) && field.hasTerrain('Psychic')) ||
-    (move.named('Misty Explosion') && isGrounded(attacker, field) && field.hasTerrain('Misty'))
+    (move.named('Misty Explosion') && isGrounded(attacker, field) && field.hasTerrain('Misty')) ||
+    (move.named('Grav Apple') && field.isGravity)
   ) {
     bpMods.push(6144);
     desc.moveBP = basePower * 1.5;

--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -748,7 +748,6 @@ export function calculateBPModsSMSS(
   hasAteAbilityTypeChange: boolean,
   turnOrder: string
 ) {
-  
   const bpMods = [];
 
   // Move effects
@@ -790,7 +789,7 @@ export function calculateBPModsSMSS(
     bpMods.push(2048);
     desc.moveBP = basePower / 2;
     desc.weather = field.weather;
-  } 
+  }
 
   if (field.attackerSide.isHelpingHand) {
     bpMods.push(6144);
@@ -810,7 +809,7 @@ export function calculateBPModsSMSS(
     }
   }
   if (isGrounded(defender, field)) {
-    if ((field.hasTerrain('Misty') && move.hasType('Dragon')) || 
+    if ((field.hasTerrain('Misty') && move.hasType('Dragon')) ||
         (field.hasTerrain('Grassy') && move.named('Bulldoze', 'Earthquake'))
     ) {
       bpMods.push(2048);
@@ -851,13 +850,13 @@ export function calculateBPModsSMSS(
       if (isAttackerAura) desc.attackerAbility = attacker.ability;
       if (isDefenderAura) desc.defenderAbility = defender.ability;
     }
-  } 
+  }
 
   // Sheer Force does not power up max moves or remove the effects (SadisticMystic)
   if ((attacker.hasAbility('Sheer Force') && move.secondaries && !move.isMax) ||
       (attacker.hasAbility('Sand Force') && field.hasWeather('Sand') && move.hasType('Rock', 'Ground', 'Steel')) ||
       (attacker.hasAbility('Analytic') && (turnOrder !== 'first' || field.defenderSide.isSwitching === 'out')) ||
-      (attacker.hasAbility('Tough Claws') && move.flags.contact) || 
+      (attacker.hasAbility('Tough Claws') && move.flags.contact) ||
       (attacker.hasAbility('Punk Rock') && move.flags.sound)
   ) {
     bpMods.push(5325);

--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -256,7 +256,8 @@ export function calculateSMSS(
         (defender.hasType('Flying') || defender.weightkg >= 200 || field.isGravity)) ||
       (move.named('Synchronoise') && !defender.hasType(attacker.types[0]) &&
         (!attacker.types[1] || !defender.hasType(attacker.types[1]))) ||
-      (move.named('Dream Eater') && !(defender.hasStatus('slp') || defender.hasAbility('Comatose'))) ||
+      (move.named('Dream Eater') &&
+        (!(defender.hasStatus('slp') || defender.hasAbility('Comatose')))) ||
       (move.named('Steel Roller') && !field.terrain) ||
       (move.named('Poltergeist') && !defender.item)
   ) {
@@ -772,15 +773,15 @@ export function calculateBPModsSMSS(
   }
 
   if ((move.named('Facade') && attacker.hasStatus('brn', 'par', 'psn', 'tox')) ||
-      (move.named('Brine') && defender.curHP() <= defender.maxHP() / 2) ||
-      (move.named('Venoshock') && defender.hasStatus('psn', 'tox')) ||
-      (move.named('Rising Voltage') && isGrounded(defender, field) && field.hasTerrain('Electric'))
+    (move.named('Brine') && defender.curHP() <= defender.maxHP() / 2) ||
+    (move.named('Venoshock') && defender.hasStatus('psn', 'tox')) ||
+    (move.named('Rising Voltage') && isGrounded(defender, field) && field.hasTerrain('Electric'))
   ) {
     bpMods.push(8192);
     desc.moveBP = basePower * 2;
   } else if ((move.named('Knock Off') && !resistedKnockOffDamage) ||
-             (move.named('Expanding Force') && isGrounded(attacker, field) && field.hasTerrain('Psychic')) ||
-             (move.named('Misty Explosion') && isGrounded(attacker, field) && field.hasTerrain('Misty'))
+    (move.named('Expanding Force') && isGrounded(attacker, field) && field.hasTerrain('Psychic')) ||
+    (move.named('Misty Explosion') && isGrounded(attacker, field) && field.hasTerrain('Misty'))
   ) {
     bpMods.push(6144);
     desc.moveBP = basePower * 1.5;
@@ -821,11 +822,13 @@ export function calculateBPModsSMSS(
 
   // Technician looks at the move's original BP, not the BP up to this point
   if ((attacker.hasAbility('Technician') && move.bp <= 60) ||
-      (attacker.hasAbility('Flare Boost') && attacker.hasStatus('brn') && move.category === 'Special') ||
-      (attacker.hasAbility('Toxic Boost') && attacker.hasStatus('psn', 'tox') && move.category === 'Physical') ||
-      (attacker.hasAbility('Mega Launcher') && move.flags.pulse) ||
-      (attacker.hasAbility('Strong Jaw') && move.flags.bite) ||
-      (attacker.hasAbility('Steely Spirit') && move.hasType('Steel'))
+    (attacker.hasAbility('Flare Boost') &&
+      attacker.hasStatus('brn') && move.category === 'Special') ||
+    (attacker.hasAbility('Toxic Boost') &&
+      attacker.hasStatus('psn', 'tox') && move.category === 'Physical') ||
+    (attacker.hasAbility('Mega Launcher') && move.flags.pulse) ||
+    (attacker.hasAbility('Strong Jaw') && move.flags.bite) ||
+    (attacker.hasAbility('Steely Spirit') && move.hasType('Steel'))
   ) {
     bpMods.push(6144);
     desc.attackerAbility = attacker.ability;
@@ -854,8 +857,10 @@ export function calculateBPModsSMSS(
 
   // Sheer Force does not power up max moves or remove the effects (SadisticMystic)
   if ((attacker.hasAbility('Sheer Force') && move.secondaries && !move.isMax) ||
-      (attacker.hasAbility('Sand Force') && field.hasWeather('Sand') && move.hasType('Rock', 'Ground', 'Steel')) ||
-      (attacker.hasAbility('Analytic') && (turnOrder !== 'first' || field.defenderSide.isSwitching === 'out')) ||
+      (attacker.hasAbility('Sand Force') &&
+        field.hasWeather('Sand') && move.hasType('Rock', 'Ground', 'Steel')) ||
+      (attacker.hasAbility('Analytic') &&
+        (turnOrder !== 'first' || field.defenderSide.isSwitching === 'out')) ||
       (attacker.hasAbility('Tough Claws') && move.flags.contact) ||
       (attacker.hasAbility('Punk Rock') && move.flags.sound)
   ) {

--- a/import/.eslintrc
+++ b/import/.eslintrc
@@ -4,7 +4,7 @@
   "rules": {
     "max-len": [
       "error", {
-        "code": 100,
+        "code": 120,
         "ignorePattern": "^\\s*['\"`/]"
       }
     ]

--- a/import/.eslintrc
+++ b/import/.eslintrc
@@ -4,7 +4,7 @@
   "rules": {
     "max-len": [
       "error", {
-        "code": 120,
+        "code": 100,
         "ignorePattern": "^\\s*['\"`/]"
       }
     ]


### PR DESCRIPTION
Implements most of the base power issues in https://github.com/smogon/damage-calc/issues/443; I didn't want to do everything at once so it'd be easier to code review. Notably, I did not implement the Speed-based modifier chaining yet; I'll need to think about that some more and want to tackle it in a separate PR once I take care of the low-hanging fruit.

Moves with custom BP:
- Steel Roller and Poltergeist now fail earlier before even entering BP calculation
- Payback, Acrobatics, Weather Ball now no longer use hardcoded damage values
- Pursuit was changed to be a move with variable base power
- Smelling Salts and Triple Kick were added as moves with variable base power
- Gyro Ball's formula was corrected

Base Power modifiers:
- BP modifiers are now grouped by effect type (move, ability, etc.) then by modifier
- Zamazenta with Rusted Shield doesn't increase Knock Off
- Expanding Force, Rising Voltage, and Misty Explosion changed to base power modifiers
- Technician's mechanics were corrected (the past theory about temporary chaining is very wrong)
- Aura mechanics were corrected (they only apply once)
- Punk Rock (offensive) changed to a base power modifier

Misc:
- Terrain Pulse and Nature Power now list their typing and base power in desc