### PR TITLE
Fix Dauntless Shield

### DIFF
--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -58,6 +58,8 @@ export function calculateSMSS(
   checkKlutz(defender);
   checkSeedBoost(attacker, field);
   checkSeedBoost(defender, field);
+  checkDauntlessShield(attacker);
+  checkDauntlessShield(defender);
 
   computeFinalStats(gen, attacker, defender, field, 'def', 'spd', 'spe');
 
@@ -67,8 +69,6 @@ export function calculateSMSS(
   checkDownload(defender, attacker);
   checkIntrepidSword(attacker);
   checkIntrepidSword(defender);
-  checkDauntlessShield(attacker);
-  checkDauntlessShield(defender);
 
   computeFinalStats(gen, attacker, defender, field, 'atk', 'spa');
 


### PR DESCRIPTION
The Dauntless Shield check was being run after the final defense stats were calculated. I don't understand why `computeFinalStats` has to be run separately for defense and attack anyway, but yeah this is why it was bugged the whole time.