### PR TITLE
Nature Power fixes

### DIFF
--- a/calc/src/mechanics/gen3.ts
+++ b/calc/src/mechanics/gen3.ts
@@ -124,6 +124,11 @@ export function calculateADV(
       desc.moveBP = bp;
     }
     break;
+  case 'Nature Power':
+    move.category = 'Special';
+    bp = 60;
+    desc.moveName = 'Swift';
+    break;
   default:
     bp = move.bp;
   }

--- a/calc/src/mechanics/gen3.ts
+++ b/calc/src/mechanics/gen3.ts
@@ -125,7 +125,7 @@ export function calculateADV(
     }
     break;
   case 'Nature Power':
-    move.category = 'Special';
+    move.category = 'Physical';
     bp = 60;
     desc.moveName = 'Swift';
     break;

--- a/calc/src/mechanics/gen4.ts
+++ b/calc/src/mechanics/gen4.ts
@@ -209,6 +209,11 @@ export function calculateDPP(
       desc.moveBP = basePower;
     }
     break;
+  case 'Nature Power':
+    move.category = 'Special';
+    basePower = 80;
+    desc.moveName = 'Tri Attack';
+    break;
   case 'Crush Grip':
   case 'Wring Out':
     basePower = Math.floor((defender.curHP() * 120) / defender.maxHP()) + 1;

--- a/calc/src/mechanics/gen4.ts
+++ b/calc/src/mechanics/gen4.ts
@@ -211,6 +211,7 @@ export function calculateDPP(
     break;
   case 'Nature Power':
     move.category = 'Special';
+    move.secondaries = true;
     basePower = 80;
     desc.moveName = 'Tri Attack';
     break;

--- a/calc/src/mechanics/gen56.ts
+++ b/calc/src/mechanics/gen56.ts
@@ -119,7 +119,6 @@ export function calculateBWXY(
         field.hasTerrain('Electric') ? 'Electric'
         : field.hasTerrain('Grassy') ? 'Grass'
         : field.hasTerrain('Misty') ? 'Fairy'
-        : field.hasTerrain('Psychic') ? 'Psychic'
         : 'Normal';
     }
   }
@@ -350,6 +349,7 @@ export function calculateBWXY(
   case 'Nature Power':
     if (gen.num === 5) {
       move.category = 'Physical';
+      move.target = 'allAdjacent';
       basePower = 100;
       desc.moveName = 'Earthquake';
     } else {

--- a/calc/src/mechanics/gen56.ts
+++ b/calc/src/mechanics/gen56.ts
@@ -112,12 +112,16 @@ export function calculateBWXY(
     desc.moveBP = move.bp;
     desc.moveType = move.type;
   } else if (move.named('Nature Power')) {
-    move.type =
-      field.hasTerrain('Electric') ? 'Electric'
-      : field.hasTerrain('Grassy') ? 'Grass'
-      : field.hasTerrain('Misty') ? 'Fairy'
-      : field.hasTerrain('Psychic') ? 'Psychic'
-      : 'Normal';
+    if (gen.num === 5) {
+      move.type = 'Ground';
+    } else {
+      move.type =
+        field.hasTerrain('Electric') ? 'Electric'
+        : field.hasTerrain('Grassy') ? 'Grass'
+        : field.hasTerrain('Misty') ? 'Fairy'
+        : field.hasTerrain('Psychic') ? 'Psychic'
+        : 'Normal';
+    }
   }
 
   let isAerilate = false;
@@ -344,10 +348,34 @@ export function calculateBWXY(
     desc.moveBP = basePower;
     break;
   case 'Nature Power':
-    basePower =
-        field.terrain && field.hasTerrain('Electric', 'Grassy') ? 90
-        : field.hasTerrain('Misty') ? 95
-        : 80; // Tri Attack
+    if (gen.num === 5) {
+      move.category = 'Physical';
+      basePower = 100;
+      desc.moveName = 'Earthquake';
+    } else {
+      move.category = 'Special';
+      switch (field.terrain) {
+      case 'Electric':
+        basePower = 90;
+        desc.moveName = 'Thunderbolt';
+        break;
+      case 'Grassy':
+        basePower = 90;
+        desc.moveName = 'Energy Ball';
+        break;
+      case 'Misty':
+        basePower = 95;
+        desc.moveName = 'Moonblast';
+        break;
+      case 'Psychic':
+        basePower = 90;
+        desc.moveName = 'Psychic';
+        break;
+      default:
+        basePower = 80;
+        desc.moveName = 'Tri Attack';
+      }
+    }
     break;
   // Triple Kick's damage doubles after each consecutive hit (10, 20, 30), this is a hack
   case 'Triple Kick':

--- a/calc/src/mechanics/gen56.ts
+++ b/calc/src/mechanics/gen56.ts
@@ -368,10 +368,6 @@ export function calculateBWXY(
         basePower = 95;
         desc.moveName = 'Moonblast';
         break;
-      case 'Psychic':
-        basePower = 90;
-        desc.moveName = 'Psychic';
-        break;
       default:
         basePower = 80;
         desc.moveName = 'Tri Attack';

--- a/calc/src/mechanics/gen56.ts
+++ b/calc/src/mechanics/gen56.ts
@@ -354,6 +354,7 @@ export function calculateBWXY(
       desc.moveName = 'Earthquake';
     } else {
       move.category = 'Special';
+      move.secondaries = true;
       switch (field.terrain) {
       case 'Electric':
         basePower = 90;

--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -678,11 +678,28 @@ export function calculateBasePowerSMSS(
     }
     break;
   case 'Nature Power':
-    basePower =
-        field.terrain && field.hasTerrain('Electric', 'Grassy', 'Psychic') ? 90
-        : field.hasTerrain('Misty') ? 95
-        : 80; // Tri Attack
-    desc.moveBP = basePower;
+    move.category = 'Special';
+    switch (field.terrain) {
+    case 'Electric':
+      basePower = 90;
+      desc.moveName = 'Thunderbolt';
+      break;
+    case 'Grassy':
+      basePower = 90;
+      desc.moveName = 'Energy Ball';
+      break;
+    case 'Misty':
+      basePower = 95;
+      desc.moveName = 'Moonblast';
+      break;
+    case 'Psychic':
+      basePower = 90;
+      desc.moveName = 'Psychic';
+      break;
+    default:
+      basePower = 80;
+      desc.moveName = 'Tri Attack';
+    }
     break;
   case 'Water Shuriken':
     basePower = attacker.named('Greninja-Ash') && attacker.hasAbility('Battle Bond') ? 20 : 15;

--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -679,6 +679,7 @@ export function calculateBasePowerSMSS(
     break;
   case 'Nature Power':
     move.category = 'Special';
+    move.secondaries = true;
     switch (field.terrain) {
     case 'Electric':
       basePower = 90;

--- a/calc/src/move.ts
+++ b/calc/src/move.ts
@@ -150,10 +150,6 @@ export class Move implements State.Move {
       // Assume max happiness for these moves because the calc doesn't support happiness
       if (['return', 'frustration', 'pikapapow', 'veeveevolley'].includes(data.id)) {
         this.bp = 102;
-      } else if (data.id === 'naturepower') {
-        // Assume the 'Wi-Fi' default of Tri Attack
-        this.bp = 80;
-        if (gen.num >= 5) this.secondaries = true;
       }
     }
   }


### PR DESCRIPTION
- Correctly adjusts move category
- Uses correct moves for gens 3 and 5 (swift and earthquake respectively)
- Changes the move name in the calc description to match the move being used (so Thunderbolt will show up in the calc description if Nature Power is selected in Electric Terrain)