### PR TITLE
Fix various Speed mechanics

### DIFF
--- a/calc/src/mechanics/gen56.ts
+++ b/calc/src/mechanics/gen56.ts
@@ -272,13 +272,13 @@ export function calculateBWXY(
     desc.moveBP = basePower;
     break;
   case 'Electro Ball':
-    if (defender.stats.spe === 0) defender.stats.spe = 1; 
+    if (defender.stats.spe === 0) defender.stats.spe = 1;
     const r = Math.floor(attacker.stats.spe / defender.stats.spe);
     basePower = r >= 4 ? 150 : r >= 3 ? 120 : r >= 2 ? 80 : r >= 1 ? 60 : 40;
     desc.moveBP = basePower;
     break;
   case 'Gyro Ball':
-    if (attacker.stats.spe === 0) attacker.stats.spe = 1; 
+    if (attacker.stats.spe === 0) attacker.stats.spe = 1;
     basePower = Math.min(150, Math.floor((25 * defender.stats.spe) / attacker.stats.spe) + 1);
     desc.moveBP = basePower;
     break;

--- a/calc/src/mechanics/gen56.ts
+++ b/calc/src/mechanics/gen56.ts
@@ -272,11 +272,13 @@ export function calculateBWXY(
     desc.moveBP = basePower;
     break;
   case 'Electro Ball':
+    if (defender.stats.spe === 0) defender.stats.spe = 1; 
     const r = Math.floor(attacker.stats.spe / defender.stats.spe);
     basePower = r >= 4 ? 150 : r >= 3 ? 120 : r >= 2 ? 80 : r >= 1 ? 60 : 40;
     desc.moveBP = basePower;
     break;
   case 'Gyro Ball':
+    if (attacker.stats.spe === 0) attacker.stats.spe = 1; 
     basePower = Math.min(150, Math.floor((25 * defender.stats.spe) / attacker.stats.spe) + 1);
     desc.moveBP = basePower;
     break;
@@ -521,7 +523,7 @@ export function calculateBWXY(
     }
   }
 
-  basePower = OF16(Math.max(1, pokeRound((basePower * chainMods(bpMods)) / 4096)));
+  basePower = OF16(Math.max(1, pokeRound((basePower * chainMods(bpMods, 41, 2097152)) / 4096)));
 
   // #endregion
   // #region (Special) Attack
@@ -614,7 +616,7 @@ export function calculateBWXY(
     desc.attackerItem = attacker.item;
   }
 
-  attack = OF16(Math.max(1, pokeRound((attack * chainMods(atMods)) / 4096)));
+  attack = OF16(Math.max(1, pokeRound((attack * chainMods(atMods, 410, 131072)) / 4096)));
 
   // #endregion
   // #region (Special) Defense
@@ -680,7 +682,7 @@ export function calculateBWXY(
     desc.defenderAbility = defender.ability;
   }
 
-  defense = OF16(Math.max(1, pokeRound((defense * chainMods(dfMods)) / 4096)));
+  defense = OF16(Math.max(1, pokeRound((defense * chainMods(dfMods, 410, 131072)) / 4096)));
 
   // #endregion
   // #region Damage
@@ -808,7 +810,7 @@ export function calculateBWXY(
     desc.isProtected = true;
   }
 
-  const finalMod = chainMods(finalMods);
+  const finalMod = chainMods(finalMods, 41, 131072);
 
   let childDamage: number[] | undefined;
   if (attacker.hasAbility('Parental Bond') && move.hits === 1 && !isSpread) {

--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -585,12 +585,12 @@ export function calculateBasePowerSMSS(
   case 'Electro Ball':
     const r = Math.floor(attacker.stats.spe / defender.stats.spe);
     basePower = r >= 4 ? 150 : r >= 3 ? 120 : r >= 2 ? 80 : r >= 1 ? 60 : 40;
-    if (defender.stats.spe === 0) basePower = 40; 
+    if (defender.stats.spe === 0) basePower = 40;
     desc.moveBP = basePower;
     break;
   case 'Gyro Ball':
     basePower = Math.min(150, Math.floor((25 * defender.stats.spe) / attacker.stats.spe) + 1);
-    if (attacker.stats.spe === 0) basePower = 1; 
+    if (attacker.stats.spe === 0) basePower = 1;
     desc.moveBP = basePower;
     break;
   case 'Punishment':

--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -479,7 +479,7 @@ export function calculateSMSS(
     desc.isProtected = true;
   }
 
-  const finalMod = chainMods(finalMods);
+  const finalMod = chainMods(finalMods, 41, 131072);
 
   let childDamage: number[] | undefined;
   if (attacker.hasAbility('Parental Bond') && move.hits === 1 && !isSpread) {
@@ -585,10 +585,12 @@ export function calculateBasePowerSMSS(
   case 'Electro Ball':
     const r = Math.floor(attacker.stats.spe / defender.stats.spe);
     basePower = r >= 4 ? 150 : r >= 3 ? 120 : r >= 2 ? 80 : r >= 1 ? 60 : 40;
+    if (defender.stats.spe === 0) basePower = 40; 
     desc.moveBP = basePower;
     break;
   case 'Gyro Ball':
     basePower = Math.min(150, Math.floor((25 * defender.stats.spe) / attacker.stats.spe) + 1);
+    if (attacker.stats.spe === 0) basePower = 1; 
     desc.moveBP = basePower;
     break;
   case 'Punishment':
@@ -730,7 +732,7 @@ export function calculateBasePowerSMSS(
     hasAteAbilityTypeChange,
     turnOrder
   );
-  basePower = OF16(Math.max(1, pokeRound((basePower * chainMods(bpMods)) / 4096)));
+  basePower = OF16(Math.max(1, pokeRound((basePower * chainMods(bpMods, 41, 2097152)) / 4096)));
   return basePower;
 }
 
@@ -984,7 +986,7 @@ export function calculateAttackSMSS(
     desc.attackerAbility = attacker.ability;
   }
   const atMods = calculateAtModsSMSS(gen, attacker, defender, move, field, desc);
-  attack = OF16(Math.max(1, pokeRound((attack * chainMods(atMods)) / 4096)));
+  attack = OF16(Math.max(1, pokeRound((attack * chainMods(atMods, 410, 131072)) / 4096)));
   return attack;
 }
 
@@ -1121,7 +1123,7 @@ export function calculateDefenseSMSS(
     hitsPhysical
   );
 
-  return OF16(Math.max(1, pokeRound((defense * chainMods(dfMods)) / 4096)));
+  return OF16(Math.max(1, pokeRound((defense * chainMods(dfMods, 410, 131072)) / 4096)));
 }
 
 export function calculateDfModsSMSS(

--- a/calc/src/mechanics/util.ts
+++ b/calc/src/mechanics/util.ts
@@ -35,10 +35,10 @@ export function isGrounded(pokemon: Pokemon, field: Field) {
 }
 
 export function getModifiedStat(stat: number, mod: number, gen?: Generation) {
-  const boostTable = [1, 1.5, 2, 2.5, 3, 3.5, 4];
   if (gen && gen.num < 3) {
     if (mod >= 0) {
-      stat = Math.floor(stat * boostTable[mod]);
+      const pastGenBoostTable = [1, 1.5, 2, 2.5, 3, 3.5, 4];
+      stat = Math.floor(stat * pastGenBoostTable[mod]);
     } else {
       const numerators = [100, 66, 50, 40, 33, 28, 25];
       stat = Math.floor((stat * numerators[-mod]) / 100);
@@ -46,11 +46,24 @@ export function getModifiedStat(stat: number, mod: number, gen?: Generation) {
     return Math.min(999, Math.max(1, stat));
   }
 
-  if (mod >= 0) {
-    stat = Math.floor(stat * boostTable[mod]);
-  } else {
-    stat = Math.floor(stat / boostTable[-mod]);
-  }
+  const numerator = 0;
+  const denominator = 1;
+  const modernGenBoostTable = [
+    [2, 8],
+    [2, 7],
+    [2, 6],
+    [2, 5],
+    [2, 4],
+    [2, 3],
+    [2, 2],
+    [3, 2],
+    [4, 2],
+    [5, 2],
+    [6, 2],
+    [7, 2],
+    [8, 2]
+  ]
+  stat = Math.floor(OF16(stat * modernGenBoostTable[6 + mod][numerator]) / modernGenBoostTable[6 + mod][denominator]);
 
   return stat;
 }
@@ -82,15 +95,11 @@ export function getFinalSpeed(gen: Generation, pokemon: Pokemon, field: Field, s
   const weather = field.weather || '';
   const terrain = field.terrain;
   let speed = getModifiedStat(pokemon.rawStats.spe, pokemon.boosts.spe, gen);
-  let mods = 1;
+  const speedMods = [];
 
-  if (pokemon.hasItem('Choice Scarf')) {
-    mods *= 1.5;
-  } else if (pokemon.hasItem('Iron Ball', ...EV_ITEMS)) {
-    mods *= 0.5;
-  } else if (pokemon.hasItem('Quick Powder') && pokemon.named('Ditto')) {
-    mods *= 2;
-  }
+  if (side.isTailwind) speedMods.push(8192);
+  // Pledge swamp would get applied here when implemented
+  // speedMods.push(1024);
 
   if ((pokemon.hasAbility('Unburden') && pokemon.abilityOn) ||
       (pokemon.hasAbility('Chlorophyll') && weather.includes('Sun')) ||
@@ -99,21 +108,28 @@ export function getFinalSpeed(gen: Generation, pokemon: Pokemon, field: Field, s
       (pokemon.hasAbility('Slush Rush') && weather === 'Hail') ||
       (pokemon.hasAbility('Surge Surfer') && terrain === 'Electric')
   ) {
-    speed *= 2;
+    speedMods.push(8192);
   } else if (pokemon.hasAbility('Quick Feet') && pokemon.status) {
-    mods *= 1.5;
+    speedMods.push(6144);
   } else if (pokemon.hasAbility('Slow Start') && pokemon.abilityOn) {
-    mods *= 0.5;
+    speedMods.push(2048);
   }
 
-  if (side.isTailwind) mods *= 2;
-  speed = pokeRound(speed * mods);
+  if (pokemon.hasItem('Choice Scarf')) {
+    speedMods.push(6144);
+  } else if (pokemon.hasItem('Iron Ball', ...EV_ITEMS)) {
+    speedMods.push(2048);
+  } else if (pokemon.hasItem('Quick Powder') && pokemon.named('Ditto')) {
+    speedMods.push(8192);
+  }
+
+  speed = OF32(pokeRound((speed * chainMods(speedMods, 410, 131172)) / 4096));
   if (pokemon.hasStatus('par') && !pokemon.hasAbility('Quick Feet')) {
-    speed = Math.floor(speed * (gen.num < 7 ? 0.25 : 0.5));
+    speed = Math.floor(OF32(speed * (gen.num < 7 ? 25 : 50)) / 100);
   }
 
   speed = Math.min(gen.num <= 2 ? 999 : 10000, speed);
-  return Math.max(1, speed);
+  return Math.max(0, speed);
 }
 
 export function getMoveEffectiveness(
@@ -330,14 +346,14 @@ export function checkMultihitBoost(
   return usedWhiteHerb;
 }
 
-export function chainMods(mods: number[]) {
+export function chainMods(mods: number[], lowerBound: number, upperBound: number) {
   let M = 4096;
   for (const mod of mods) {
     if (mod !== 4096) {
       M = (M * mod + 2048) >> 12;
     }
   }
-  return M;
+  return Math.max(Math.min(M, upperBound), lowerBound);
 }
 
 export function getBaseDamage(level: number, basePower: number, attack: number, defense: number) {

--- a/calc/src/mechanics/util.ts
+++ b/calc/src/mechanics/util.ts
@@ -61,9 +61,10 @@ export function getModifiedStat(stat: number, mod: number, gen?: Generation) {
     [5, 2],
     [6, 2],
     [7, 2],
-    [8, 2]
-  ]
-  stat = Math.floor(OF16(stat * modernGenBoostTable[6 + mod][numerator]) / modernGenBoostTable[6 + mod][denominator]);
+    [8, 2],
+  ];
+  stat = OF16(stat * modernGenBoostTable[6 + mod][numerator]);
+  stat = Math.floor(stat / modernGenBoostTable[6 + mod][denominator]);
 
   return stat;
 }


### PR DESCRIPTION
This implements a number of fixes to calculating Speed, including:

- Speed now has a proper floor of 0; the Gyro Ball and Electro Ball edge cases are implemented to reflect this
- Speed now uses proper modifier chaining
- Lower / upper bounds are implemented on all chained modifiers; in practice, this will only end up mattering for Speed
- Applying stat boosts / drops for stat calculation in Gen 3+ now accounts for 16-bit overflow