### PR TITLE
Ripen not applied to super effective berries

### DIFF
--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -1287,7 +1287,11 @@ export function calculateFinalModsSMSS(
   if (move.hasType(getBerryResistType(defender.item)) &&
       (typeEffectiveness > 1 || move.hasType('Normal')) &&
       !attacker.hasAbility('Unnerve', 'As One (Glastrier)', 'As One (Spectrier)')) {
-    finalMods.push(2048);
+    if (defender.hasAbility('Ripen')) {
+      finalMods.push(1024);
+    } else {
+      finalMods.push(2048);
+    }
     desc.defenderItem = defender.item;
   }
 


### PR DESCRIPTION
I was messing around testing something on Flapple. I noticed the damage calculation was the same on ice moves with a Yache Berry held with and without Ripen as the ability. Ripen should double the effect of all berries. So a super effective attack should deal 1/4th damage and not half damage. I believe this should fix that case assuming I understood the surrounding code in regards to the damage formula.