### PR TITLE
Fix Technician's interaction with custom BP moves

### DIFF
--- a/calc/src/mechanics/gen56.ts
+++ b/calc/src/mechanics/gen56.ts
@@ -374,7 +374,8 @@ export function calculateBWXY(
 
   const bpMods = [];
 
-  if ((attacker.hasAbility('Technician') && move.bp <= 60) ||
+  // Use BasePower after moves with custom BP to determine if Technician should boost
+  if ((attacker.hasAbility('Technician') && basePower <= 60) ||
       (attacker.hasAbility('Flare Boost') &&
        attacker.hasStatus('brn') && move.category === 'Special') ||
       (attacker.hasAbility('Toxic Boost') &&

--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -829,8 +829,8 @@ export function calculateBPModsSMSS(
 
   // Abilities
 
-  // Technician looks at the move's original BP, not the BP up to this point
-  if ((attacker.hasAbility('Technician') && move.bp <= 60) ||
+  // Use BasePower after moves with custom BP to determine if Technician should boost
+  if ((attacker.hasAbility('Technician') && basePower <= 60) ||
     (attacker.hasAbility('Flare Boost') &&
       attacker.hasStatus('brn') && move.category === 'Special') ||
     (attacker.hasAbility('Toxic Boost') &&

--- a/calc/src/test/calc.test.ts
+++ b/calc/src/test/calc.test.ts
@@ -571,6 +571,22 @@ describe('calc', () => {
           '+1 252 SpA Choice Specs Gengar Focus Blast vs. 252 HP / 252+ SpD Eviolite Chansey: 274-324 (18 - 22px) -- guaranteed 3HKO'
         );
       });
+      test('Technician with Low Kick', () => {
+          const ambipom = Pokemon('Ambipom', {level: 50, ability: 'Technician'});
+          const blissey = Pokemon('Blissey', {level: 50, evs: {hp: 252}});
+          let result = calculate(ambipom, blissey, Move('Low Kick'));
+          expect(result.range()).toEqual([272, 320]);
+          expect(result.desc()).toBe(
+            '0 Atk Technician Ambipom Low Kick (60 BP) vs. 252 HP / 0 Def Blissey: 272-320 (75.1 - 88.3%) -- guaranteed 2HKO'
+          );
+
+          const aggron = Pokemon('Aggron', {level: 50, evs: {hp: 252}});
+          result = calculate(ambipom, aggron, Move('Low Kick'));
+          expect(result.range()).toEqual([112, 132]);
+          expect(result.desc()).toBe(
+            '0 Atk Ambipom Low Kick (120 BP) vs. 252 HP / 0 Def Aggron: 112-132 (63.2 - 74.5%) -- guaranteed 2HKO'
+          );
+      });
     });
   });
 
@@ -839,6 +855,23 @@ describe('calc', () => {
           '252 SpA Choice Specs Kyurem Earth Power vs. 0 HP / 0 SpD Jirachi: 294-348 (86.2 - 102%) -- 12.5% chance to OHKO'
         );
       });
+
+      test('Technician with Low Kick', () => {
+        const ambipom = Pokemon('Ambipom', {level: 50, ability: 'Technician'});
+        const blissey = Pokemon('Blissey', {level: 50, evs: {hp: 252}});
+        let result = calculate(ambipom, blissey, Move('Low Kick'));
+        expect(result.range()).toEqual([272, 320]);
+        expect(result.desc()).toBe(
+          '0 Atk Technician Ambipom Low Kick (60 BP) vs. 252 HP / 0 Def Blissey: 272-320 (75.1 - 88.3%) -- guaranteed 2HKO'
+        );
+
+        const aggron = Pokemon('Aggron', {level: 50, evs: {hp: 252}});
+        result = calculate(ambipom, aggron, Move('Low Kick'));
+        expect(result.range()).toEqual([112, 132]);
+        expect(result.desc()).toBe(
+          '0 Atk Ambipom Low Kick (120 BP) vs. 252 HP / 0 Def Aggron: 112-132 (63.2 - 74.5%) -- guaranteed 2HKO'
+        );
+    });
     });
   });
 });


### PR DESCRIPTION
Using basePower instead of move.bp to correctly apply (and not apply) technician for moves with custom bp