### PR TITLE
Update README adaptable example to pass correct arguments to calculate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,15 @@ with the adaptable entry point for applications which want to avoid having two s
 same data shipped to users.
 
 ```ts
+import {Dex} from '@pkmn/dex';
 import {Generations} from '@pkmn/data';
 import {calculate, Pokemon, Move, Field} from '@smogon/calc/adaptable';
 
-const gen = Generations.get(1);
+const gens = new Generations(Dex);
+
+const gen = gens.get(1);
 const result = calculate(
+  gen,
   new Pokemon(gen, 'Gengar'),
   new Pokemon(gen, 'Vulpix'),
   new Move(gen, 'Surf'),


### PR DESCRIPTION
Was trying to use smogon\calc with @scheibo 's wonderful PKM packages, and I needed to make this change to properly do that, so I thought I would correct the example code (the example code before was ignoring the first generations argument it looks like... which meant some code was trying to access .num on a Gengar where it expected a generation). 

On another note, I also needed to change: 

'@smogon/calc/adaptable';  to instead be     '@smogon/calc/dist/adaptable.js'; 

to get my local project working properly when importing stuff from adaptable, but I assume that is just some local issue with my webpack config, so I did not put it in the docs.