### PR TITLE
Population Bomb should not be guaranteed to hit 10 times

### DIFF
--- a/calc/src/data/moves.ts
+++ b/calc/src/data/moves.ts
@@ -4395,7 +4395,7 @@ const SV_PATCH: {[name: string]: DeepPartial<MoveData>} = {
     zp: 100,
     maxPower: 90,
     makesContact: true,
-    multihit: 10,
+    multihit: [1-10],
   },
   Pounce: {
     bp: 50,

--- a/calc/src/data/moves.ts
+++ b/calc/src/data/moves.ts
@@ -4395,7 +4395,7 @@ const SV_PATCH: {[name: string]: DeepPartial<MoveData>} = {
     zp: 100,
     maxPower: 90,
     makesContact: true,
-    multihit: [1-10],
+    multihit: [1, 10],
   },
   Pounce: {
     bp: 50,


### PR DESCRIPTION
According to both [bubapedia](https://bulbapedia.bulbagarden.net/wiki/Population_Bomb_(move)), [serebii](https://www.serebii.net/attackdex-sv/populationbomb.shtml) and in-game experience, Population Bomb is a multi-hit move that has a 1 to 10 chances of hitting an opponent and chances to miss. 

Not guaranteed 10 hits. 

I am not familiar with the project to fix the teambuilder description, but it should be updated as well.