### PR TITLE
Fix ruin abilities

### DIFF
--- a/calc/src/desc.ts
+++ b/calc/src/desc.ts
@@ -23,6 +23,10 @@ export interface RawDesc {
   defenseEVs?: string;
   hits?: number;
   alliesFainted?: number;
+  isBeadsOfRuin?: boolean;
+  isSwordOfRuin?: boolean;
+  isTabletsOfRuin?: boolean;
+  isVesselOfRuin?: boolean;
   isAuroraVeil?: boolean;
   isFlowerGiftAttacker?: boolean;
   isFlowerGiftDefender?: boolean;
@@ -851,6 +855,11 @@ function buildDescription(description: RawDesc, attacker: Pokemon, defender: Pok
   }
   if (description.attackerTera) {
     output += `Tera ${description.attackerTera} `;
+  if (description.isBeadsOfRuin) {
+    output += 'Beads of Ruin ';
+  }
+  if (description.isSwordOfRuin) {
+    output += 'Sword of Ruin ';
   }
   output += description.attackerName + ' ';
   if (description.isHelpingHand) {
@@ -894,6 +903,12 @@ function buildDescription(description: RawDesc, attacker: Pokemon, defender: Pok
   }
   output = appendIfSet(output, description.defenderItem);
   output = appendIfSet(output, description.defenderAbility);
+  if (description.isTabletsOfRuin) {
+    output += 'Tablets of Ruin ';
+  }
+  if (description.isVesselOfRuin) {
+    output += 'Vessel of Ruin ';
+  }
   if (description.isProtected) {
     output += 'protected ';
   }

--- a/calc/src/desc.ts
+++ b/calc/src/desc.ts
@@ -855,6 +855,7 @@ function buildDescription(description: RawDesc, attacker: Pokemon, defender: Pok
   }
   if (description.attackerTera) {
     output += `Tera ${description.attackerTera} `;
+  }
   if (description.isBeadsOfRuin) {
     output += 'Beads of Ruin ';
   }

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -1203,10 +1203,17 @@ export function calculateAtModsSMSSSV(
     desc.defenderAbility = defender.ability;
   }
 
+  const isTabletsOfRuinActive = defender.hasAbility('Tablets of Ruin') || field.isTabletsOfRuin;
+  const isVesselOfRuinActive = defender.hasAbility('Vessel of Ruin') || field.isVesselOfRuin;
   if (
-    (field.isTabletsOfRuin && move.category === 'Physical') ||
-    (field.isVesselOfRuin && move.category === 'Special')
+    (isTabletsOfRuinActive && move.category === 'Physical') ||
+    (isVesselOfRuinActive && move.category === 'Special')
   ) {
+    if (defender.hasAbility('Tablets of Ruin') || defender.hasAbility('Vessel of Ruin')) {
+      desc.defenderAbility = defender.ability;
+    } else {
+      desc[move.category === 'Special' ? 'isVesselOfRuin' : 'isTabletsOfRuin'] = true;
+    }
     atMods.push(3072);
   }
 
@@ -1222,6 +1229,7 @@ export function calculateAtModsSMSSSV(
       (move.category === 'Special' && getMostProficientStat(attacker) === 'spa')
     ) {
       atMods.push(5325);
+      desc.attackerAbility = attacker.ability;
     }
   }
 
@@ -1348,10 +1356,17 @@ export function calculateDfModsSMSSSV(
     desc.defenderAbility = defender.ability;
   }
 
+  const isSwordOfRuinActive = attacker.hasAbility('Sword of Ruin') || field.isSwordOfRuin;
+  const isBeadsOfRuinActive = attacker.hasAbility('Beads of Ruin') || field.isBeadsOfRuin;
   if (
-    (field.isSwordOfRuin && hitsPhysical) ||
-    (field.isBeadsOfRuin && !hitsPhysical)
+    (isSwordOfRuinActive && hitsPhysical) ||
+    (isBeadsOfRuinActive && !hitsPhysical)
   ) {
+    if (attacker.hasAbility('Sword of Ruin') || attacker.hasAbility('Beads of Ruin')) {
+      desc.attackerAbility = attacker.ability;
+    } else {
+      desc[hitsPhysical ? 'isSwordOfRuin' : 'isBeadsOfRuin'] = true;
+    }
     dfMods.push(3072);
   }
 
@@ -1365,6 +1380,7 @@ export function calculateDfModsSMSSSV(
       (hitsPhysical && getMostProficientStat(defender) === 'def') ||
       (!hitsPhysical && getMostProficientStat(defender) === 'spd')
     ) {
+      desc.defenderAbility = defender.ability;
       dfMods.push(5324);
     }
   }

--- a/src/honkalculate.template.html
+++ b/src/honkalculate.template.html
@@ -589,7 +589,7 @@
             <div id="collapseTwo" class="panel-collapse collapse">
                 <div class="panel-body">
                     <div class="gen-specific g3 g4 g5 g6 g7 g8 g9" style="width: 10.6em; margin: 0 auto 5px;" title="Select the battle format.">
-                        <input class="visually-hidden" type="radio" name="format" value="Singles" id="singles-format" checked="checked" />
+                        <input class="visually-hidden" type="radio" name="format" value="Singles" id="singles-format" />
                         <label class="btn btn-left" for="singles-format">Singles</label>
                         <input class="visually-hidden" type="radio" name="format" value="Doubles" id="doubles-format" />
                         <label class="btn btn-right" for="doubles-format">Doubles</label>
@@ -602,6 +602,17 @@
                     <div class="gen-specific g7 g8 g9" title="Select the current terrain.">
                         <input class="visually-hidden terrain-trigger calc-trigger" type="checkbox" name="terrain" value="Psychic" id="psychic" /><label class="btn btn-xxxwide btn-mid" for="psychic">Psychic Terrain</label>
                     </div>
+						  <div aria-labelledby="selectRuinInstruction" class="gen-specific g9 format-specific doubles" role="group" style="margin: 5px auto auto;" title="Select the ruin abilities from other Pok&eacute;mon on the field.">
+								<span class="visually-hidden" id="selectRuinInstruction">Select the active Ruin abilities from other Poke&eacute;mon on the field.</span>
+								<input class="visually-hidden calc-trigger" type="checkbox" name="ruin" value="Beads" id="beads" />
+								<label class="btn btn-xxxwide btn-left" for="beads">Beads of Ruin</label>
+								<input class="visually-hidden calc-trigger" type="checkbox" name="ruin" value="Tablets" id="tablets" />
+								<label class="btn btn-xxxwide btn-mid" for="tablets">Tablets of Ruin</label>
+								<input class="visually-hidden calc-trigger" type="checkbox" name="ruin" value="Sword" id="sword" />
+								<label class="btn btn-xxxwide btn-right" for="sword">Sword of Ruin</label>
+								<input class="visually-hidden calc-trigger" type="checkbox" name="ruin" value="Vessel" id="vessel" />
+								<label class="btn btn-xxxwide btn-mid" for="vessel">Vessel of Ruin</label>
+						  </div>
                     <hr class="gen-specific g6 g7 g8 g9" />
                     <div class="gen-specific g3 g4 g5 g6 g7 g8 g9" style="width: 22.2em; margin: 5px auto;" title="Select the current weather condition.">
                         <input class="visually-hidden" type="radio" name="weather" value="" id="clear" checked="checked" />
@@ -859,6 +870,7 @@
     <script type="text/javascript" src="./calc/util.js?"></script>
     <script type="text/javascript" src="./calc/stats.js?"></script>
     <script type="text/javascript" src="./calc/data/species.js?"></script>
+    <script type="text/javascript" src="./js/data/sets/gen9.js?"></script>
     <script type="text/javascript" src="./js/data/sets/gen8.js?"></script>
     <script type="text/javascript" src="./js/data/sets/gen7.js?"></script>
     <script type="text/javascript" src="./js/data/sets/gen6.js?"></script>

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -667,7 +667,7 @@
                     <input class="visually-hidden terrain-trigger calc-trigger" type="checkbox" name="terrain" value="Misty" id="misty" /><label class="btn btn-xxxwide btn-right" for="misty">Misty Terrain</label>
                     <input class="visually-hidden terrain-trigger calc-trigger" type="checkbox" name="terrain" value="Psychic" id="psychic" /><label class="btn btn-xxxwide btn-mid" for="psychic">Psychic Terrain</label>
                 </div>
-                 <div aria-labelledby="selectRuinInstruction" class="gen-specific g9 format-specific doubles" role="group" style="margin: 5px auto auto;" title="Select the ruin abilities from other Pok&eacute;mon on the field.">
+					 <div aria-labelledby="selectRuinInstruction" class="gen-specific g9 format-specific doubles" role="group" style="margin: 5px auto auto;" title="Select the ruin abilities from other Pok&eacute;mon on the field.">
                     <span class="visually-hidden" id="selectRuinInstruction">Select the active Ruin abilities from other Poke&eacute;mon on the field.</span>
                     <input class="visually-hidden calc-trigger" type="checkbox" name="ruin" value="Beads" id="beads" />
 						  <label class="btn btn-xxxwide btn-left" for="beads">Beads of Ruin</label>

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -655,7 +655,7 @@
                 <legend align="center">Field</legend>
                 <div aria-labelledby="selectBattleFormatInstruction" class="gen-specific g3 g4 g5 g6 g7 g8 g9" role="radiogroup" style="width: 10.6em; margin: 0 auto 5px;" title="Select the battle format.">
                     <span class="visually-hidden" id="selectBattleFormatInstruction">Select the battle format.</span>
-                    <input class="visually-hidden calc-trigger" type="radio" name="format" value="Singles" id="singles-format" checked="checked" />
+                    <input class="visually-hidden calc-trigger" type="radio" name="format" value="Singles" id="singles-format" />
                     <label class="btn btn-left" for="singles-format">Singles</label>
                     <input class="visually-hidden calc-trigger" type="radio" name="format" value="Doubles" id="doubles-format" />
                     <label class="btn btn-right" for="doubles-format">Doubles</label>
@@ -666,6 +666,17 @@
                     <input class="visually-hidden terrain-trigger calc-trigger" type="checkbox" name="terrain" value="Grassy" id="grassy" /><label class="btn btn-xxxwide btn-mid" for="grassy">Grassy Terrain</label>
                     <input class="visually-hidden terrain-trigger calc-trigger" type="checkbox" name="terrain" value="Misty" id="misty" /><label class="btn btn-xxxwide btn-right" for="misty">Misty Terrain</label>
                     <input class="visually-hidden terrain-trigger calc-trigger" type="checkbox" name="terrain" value="Psychic" id="psychic" /><label class="btn btn-xxxwide btn-mid" for="psychic">Psychic Terrain</label>
+                </div>
+                 <div aria-labelledby="selectRuinInstruction" class="gen-specific g9 format-specific doubles" role="group" style="margin: 5px auto auto;" title="Select the ruin abilities from other Pok&eacute;mon on the field.">
+                    <span class="visually-hidden" id="selectRuinInstruction">Select the active Ruin abilities from other Poke&eacute;mon on the field.</span>
+                    <input class="visually-hidden calc-trigger" type="checkbox" name="ruin" value="Beads" id="beads" />
+						  <label class="btn btn-xxxwide btn-left" for="beads">Beads of Ruin</label>
+                    <input class="visually-hidden calc-trigger" type="checkbox" name="ruin" value="Tablets" id="tablets" />
+						  <label class="btn btn-xxxwide btn-mid" for="tablets">Tablets of Ruin</label>
+                    <input class="visually-hidden calc-trigger" type="checkbox" name="ruin" value="Sword" id="sword" />
+						  <label class="btn btn-xxxwide btn-right" for="sword">Sword of Ruin</label>
+                    <input class="visually-hidden calc-trigger" type="checkbox" name="ruin" value="Vessel" id="vessel" />
+						  <label class="btn btn-xxxwide btn-mid" for="vessel">Vessel of Ruin</label>
                 </div>
                 <hr class="gen-specific g6 g7 g8 g9" />
                 <div aria-labelledby="selectWeatherInstruction" role="radiogroup">

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -91,7 +91,12 @@ $("input:radio[name='format']").change(function () {
 	if (gameType === 'Singles') {
 		$("input:checkbox[name='ruin']:checked").prop("checked", false);
 	}
-	$(".format-specific." + gameType.toLowerCase()).show();
+	$(".format-specific." + gameType.toLowerCase()).each(function (){
+		if ($(this).hasClass("gen-specific") && !$(this).hasClass("g" + gen)) {
+			return;
+		}
+		$(this).show();
+	});
 	$(".format-specific").not("." + gameType.toLowerCase()).hide();
 });
 

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -86,6 +86,15 @@ function validate(obj, min, max) {
 	obj.val(Math.max(min, Math.min(max, ~~obj.val())));
 }
 
+$("input:radio[name='format']").change(function () {
+	var gameType = $("input:radio[name='format']:checked").val();
+	if (gameType === 'Singles') {
+		$("input:checkbox[name='ruin']:checked").prop("checked", false);
+	}
+	$(".format-specific." + gameType.toLowerCase()).show();
+	$(".format-specific").not("." + gameType.toLowerCase()).hide();
+});
+
 // auto-calc stats and current HP on change
 $(".level").keyup(function () {
 	var poke = $(this).closest(".poke-info");
@@ -888,6 +897,10 @@ function getMoveDetails(moveInfo, species, ability, item, useMax) {
 
 function createField() {
 	var gameType = $("input:radio[name='format']:checked").val();
+	var isBeadsOfRuin = $("#beads").prop("checked");
+	var isTabletsOfRuin = $("#tablets").prop("checked");
+	var isSwordOfRuin = $("#sword").prop("checked");
+	var isVesselOfRuin = $("#vessel").prop("checked");
 	var isMagicRoom = $("#magicroom").prop("checked");
 	var isWonderRoom = $("#wonderroom").prop("checked");
 	var isGravity = $("#gravity").prop("checked");
@@ -933,7 +946,10 @@ function createField() {
 		});
 	};
 	return new calc.Field({
-		gameType: gameType, weather: weather, terrain: terrain, isMagicRoom: isMagicRoom, isWonderRoom: isWonderRoom, isGravity: isGravity,
+		gameType: gameType, weather: weather, terrain: terrain,
+		isMagicRoom: isMagicRoom, isWonderRoom: isWonderRoom, isGravity: isGravity,
+		isBeadsOfRuin: isBeadsOfRuin, isTabletsOfRuin: isTabletsOfRuin,
+		isSwordOfRuin: isSwordOfRuin, isVesselOfRuin: isVesselOfRuin,
 		attackerSide: createSide(0), defenderSide: createSide(1)
 	});
 }
@@ -1016,6 +1032,7 @@ var RANDDEX = [
 	typeof GEN9RANDOMBATTLE === 'undefined' ? {} : GEN9RANDOMBATTLE,
 ];
 var gen, genWasChanged, notation, pokedex, setdex, randdex, typeChart, moves, abilities, items, calcHP, calcStat, GENERATION;
+
 $(".gen").change(function () {
 	/*eslint-disable */
 	gen = ~~$(this).val() || 9;
@@ -1368,6 +1385,8 @@ $(document).ready(function () {
 	$("#gen" + g).change();
 	$("#percentage").prop("checked", true);
 	$("#percentage").change();
+	$("#singles-format").prop("checked", true);
+	$("#singles-format").change();
 	loadDefaultLists();
 	$(".move-selector").select2({
 		dropdownAutoWidth: true,

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -91,7 +91,7 @@ $("input:radio[name='format']").change(function () {
 	if (gameType === 'Singles') {
 		$("input:checkbox[name='ruin']:checked").prop("checked", false);
 	}
-	$(".format-specific." + gameType.toLowerCase()).each(function (){
+	$(".format-specific." + gameType.toLowerCase()).each(function () {
 		if ($(this).hasClass("gen-specific") && !$(this).hasClass("g" + gen)) {
 			return;
 		}

--- a/src/randoms.template.html
+++ b/src/randoms.template.html
@@ -676,7 +676,7 @@
                 <legend align="center">Field</legend>
                 <div aria-labelledby="selectBattleFormatInstruction" class="gen-specific g3 g4 g5 g6 g7 g8 g9" role="radiogroup" style="width: 10.6em; margin: 0 auto 5px;" title="Select the battle format.">
                     <span class="visually-hidden" id="selectBattleFormatInstruction">Select the battle format.</span>
-                    <input class="visually-hidden calc-trigger" type="radio" name="format" value="Singles" id="singles-format" checked="checked" />
+                    <input class="visually-hidden calc-trigger" type="radio" name="format" value="Singles" id="singles-format" />
                     <label class="btn btn-left" for="singles-format">Singles</label>
                     <input class="visually-hidden calc-trigger" type="radio" name="format" value="Doubles" id="doubles-format" />
                     <label class="btn btn-right" for="doubles-format">Doubles</label>
@@ -693,6 +693,17 @@
                     <input class="visually-hidden terrain-trigger calc-trigger" type="checkbox" name="terrain" value="Grassy" id="grassy" /><label class="btn btn-xxxwide btn-mid" for="grassy">Grassy Terrain</label>
                     <input class="visually-hidden terrain-trigger calc-trigger" type="checkbox" name="terrain" value="Misty" id="misty" /><label class="btn btn-xxxwide btn-right" for="misty">Misty Terrain</label>
                     <input class="visually-hidden terrain-trigger calc-trigger" type="checkbox" name="terrain" value="Psychic" id="psychic" /><label class="btn btn-xxxwide btn-mid" for="psychic">Psychic Terrain</label>
+					 </div>
+					 <div aria-labelledby="selectRuinInstruction" class="gen-specific g9 format-specific doubles" role="group" style="margin: 5px auto auto;" title="Select the ruin abilities from other Pok&eacute;mon on the field.">
+                    <span class="visually-hidden" id="selectRuinInstruction">Select the active Ruin abilities from other Poke&eacute;mon on the field.</span>
+                    <input class="visually-hidden calc-trigger" type="checkbox" name="ruin" value="Beads" id="beads" />
+						  <label class="btn btn-xxxwide btn-left" for="beads">Beads of Ruin</label>
+                    <input class="visually-hidden calc-trigger" type="checkbox" name="ruin" value="Tablets" id="tablets" />
+						  <label class="btn btn-xxxwide btn-mid" for="tablets">Tablets of Ruin</label>
+                    <input class="visually-hidden calc-trigger" type="checkbox" name="ruin" value="Sword" id="sword" />
+						  <label class="btn btn-xxxwide btn-right" for="sword">Sword of Ruin</label>
+                    <input class="visually-hidden calc-trigger" type="checkbox" name="ruin" value="Vessel" id="vessel" />
+						  <label class="btn btn-xxxwide btn-mid" for="vessel">Vessel of Ruin</label>
                 </div>
                 <hr class="gen-specific g6 g7 g8 g9" />
                 <div aria-labelledby="selectWeatherInstruction" role="radiogroup">


### PR DESCRIPTION
~~They were previously in `Field` but were never initialized. I did not fix them by initializing them because they're not really `Field` properties because unlike terrains it doesn't effect every Pokemon on the field.~~

~~The aura abilities are also in `Field` (though those are actually field properties) and they're never initialized but they work because the abilities are checked in the relevant mechanics files. I could have removed them but maybe they serve a purpose I'm not aware or should serve a purpose later on down the road if there's a Dark/Fairy Aura button in the field control area.~~