### PR TITLE
Gen 1: Type effectiveness is applied individually

### DIFF
--- a/calc/src/mechanics/gen12.ts
+++ b/calc/src/mechanics/gen12.ts
@@ -201,9 +201,7 @@ export function calculateRBYGSC(
   if (gen.num === 1) {
     baseDamage = Math.floor(baseDamage * type1Effectiveness);
     baseDamage = Math.floor(baseDamage * type2Effectiveness);
-  }
-
-  if (gen.num === 2) {
+  } else {
     baseDamage = Math.floor(baseDamage * typeEffectiveness);
   }
 

--- a/calc/src/mechanics/gen12.ts
+++ b/calc/src/mechanics/gen12.ts
@@ -198,7 +198,14 @@ export function calculateRBYGSC(
     baseDamage = Math.floor(baseDamage * 1.5);
   }
 
-  baseDamage = Math.floor(baseDamage * typeEffectiveness);
+  if (gen.num === 1) {
+    baseDamage = Math.floor(baseDamage * type1Effectiveness);
+    baseDamage = Math.floor(baseDamage * type2Effectiveness);
+  }
+
+  if (gen.num === 2) {
+    baseDamage = Math.floor(baseDamage * typeEffectiveness);
+  }
 
   // Flail and Reversal don't use random factor
   if (move.named('Flail', 'Reversal')) {


### PR DESCRIPTION
In gen 1, type effectiveness is individually applied to each type. This can affect the damage done, e.g. Ice Beam used against Articuno. 

https://github.com/smogon/pokemon-showdown/commit/534cd35119398a901943bc5adab0db2dc8c0f42e