### PR TITLE
Support Terastallization in the UI

### DIFF
--- a/calc/src/desc.ts
+++ b/calc/src/desc.ts
@@ -14,9 +14,11 @@ export interface RawDesc {
   attackerAbility?: string;
   attackerItem?: string;
   attackerName: string;
+  attackerTera?: string;
   defenderAbility?: string;
   defenderItem?: string;
   defenderName: string;
+  defenderTera?: string;
   defenseBoost?: number;
   defenseEVs?: string;
   hits?: number;
@@ -835,6 +837,9 @@ function buildDescription(description: RawDesc, attacker: Pokemon, defender: Pok
   if (description.isBurned) {
     output += 'burned ';
   }
+  if (description.attackerTera) {
+    output += `Tera ${description.attackerTera} `;
+  }
   output += description.attackerName + ' ';
   if (description.isHelpingHand) {
     output += 'Helping Hand ';
@@ -882,6 +887,9 @@ function buildDescription(description: RawDesc, attacker: Pokemon, defender: Pok
   }
   if (description.isDefenderDynamaxed) {
     output += 'Dynamax ';
+  }
+  if (description.defenderTera) {
+    output += `Tera ${description.defenderTera} `;
   }
   output += description.defenderName;
   if (description.weather && description.terrain) {

--- a/calc/src/mechanics/gen78.ts
+++ b/calc/src/mechanics/gen78.ts
@@ -81,8 +81,10 @@ export function calculateSMSS(
 
   const desc: RawDesc = {
     attackerName: attacker.name,
+    attackerTera: attacker.teraType,
     moveName: move.name,
     defenderName: defender.name,
+    defenderTera: defender.teraType,
     isDefenderDynamaxed: defender.isDynamaxed,
     isWonderRoom: field.isWonderRoom,
   };

--- a/calc/src/pokemon.ts
+++ b/calc/src/pokemon.ts
@@ -126,7 +126,7 @@ export class Pokemon implements State.Pokemon {
 
   hasType(...types: I.TypeName[]) {
     for (const type of types) {
-      if (this.types.includes(type)) return true;
+      if (this.teraType ? this.teraType === type : this.types.includes(type)) return true;
     }
     return false;
   }

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -140,6 +140,11 @@
                     <select aria-label="type2" class="type2 terrain-trigger calc-trigger"></select>
                     <small class="right">(<a class="analysis" target="_blank" href="">Smogon&nbsp;analysis</a>)</small>
                 </div>
+					 <div class="gen-specific g9">
+						<label>Tera Type</label>
+						<select class="teraType terrain-trigger calc-trigger"></select>
+						<input type="checkbox" title= "Has this Pok&eacute;mon terastalized?" class="teraToggle terrain-trigger calc-trigger">
+					 </div>
                 <div class="hide">
                     <label>Forme</label>
                     <select class="forme calc-trigger"></select>
@@ -975,6 +980,11 @@
                     <select aria-label="Type 2" class="type2 terrain-trigger calc-trigger"></select>
                     <small class="right">(<a class="analysis" target="_blank" href="">Smogon&nbsp;analysis</a>)</small>
                 </div>
+					 <div class="gen-specific g9">
+						<label>Tera Type</label>
+						<select class="teraType terrain-trigger calc-trigger"></select>
+						<input type="checkbox" title= "Has this Pok&eacute;mon terastalized?" class="teraToggle terrain-trigger calc-trigger">
+					 </div>
                 <div class="hide">
                     <label>Forme</label>
                     <select class="forme calc-trigger"></select>

--- a/src/js/moveset_import.js
+++ b/src/js/moveset_import.js
@@ -110,7 +110,7 @@ function getStats(currentPoke, rows, offset) {
 	var currentEV;
 	var currentIV;
 	var currentAbility;
-	var currentTeraType
+	var currentTeraType;
 	var currentNature;
 	currentPoke.level = 100;
 	for (var x = offset; x < offset + 9; x++) {

--- a/src/js/moveset_import.js
+++ b/src/js/moveset_import.js
@@ -16,6 +16,7 @@ function ExportPokemon(pokeInfo) {
 	finalText = pokemon.name + (pokemon.item ? " @ " + pokemon.item : "") + "\n";
 	finalText += "Level: " + pokemon.level + "\n";
 	finalText += pokemon.nature && gen > 2 ? pokemon.nature + " Nature" + "\n" : "";
+	finalText += pokemon.teraType && gen > 8 ? "Tera Type: " + pokemon.teraType : "";
 	finalText += pokemon.ability ? "Ability: " + pokemon.ability + "\n" : "";
 	if (gen > 2) {
 		var EVs_Array = [];
@@ -82,6 +83,11 @@ function getAbility(row) {
 	if (calc.ABILITIES[9].indexOf(ability) !== -1) return ability;
 }
 
+function getTeraType(row) {
+	var teraType = row[1] ? row[1].trim() : '';
+	if (Object.keys(calc.TYPE_CHART[9]).slice(1).indexOf(teraType) !== -1) return teraType;
+}
+
 function statToLegacyStat(stat) {
 	switch (stat) {
 	case 'hp':
@@ -104,6 +110,7 @@ function getStats(currentPoke, rows, offset) {
 	var currentEV;
 	var currentIV;
 	var currentAbility;
+	var currentTeraType
 	var currentNature;
 	currentPoke.level = 100;
 	for (var x = offset; x < offset + 9; x++) {
@@ -138,6 +145,11 @@ function getStats(currentPoke, rows, offset) {
 		currentAbility = rows[x] ? rows[x].trim().split(":") : '';
 		if (currentAbility[0] == "Ability") {
 			currentPoke.ability = currentAbility[1].trim();
+		}
+
+		currentTeraType = rows[x] ? rows[x].trim().split(":") : '';
+		if (currentTeraType[0] == "Tera Type") {
+			currentPoke.teraType = currentTeraType[1].trim();
 		}
 
 		currentNature = rows[x] ? rows[x].trim().split(" ") : '';
@@ -202,6 +214,9 @@ function addToDex(poke) {
 	}
 	if (poke.ability !== undefined) {
 		dexObject.ability = poke.ability;
+	}
+	if (poke.teraType !== undefined) {
+		dexObject.teraType = poke.teraType;
 	}
 	dexObject.level = poke.level;
 	dexObject.evs = poke.evs;
@@ -275,6 +290,7 @@ function addSets(pokes, name) {
 				}
 				currentPoke.isCustomSet = true;
 				currentPoke.ability = getAbility(rows[i + 1].split(":"));
+				currentPoke.teraType = getTeraType(rows[i + 1].split(":"));
 				currentPoke = getStats(currentPoke, rows, i + 1);
 				currentPoke = getMoves(currentPoke, rows, i);
 				addToDex(currentPoke);

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -1173,7 +1173,6 @@ function getTerrainEffects() {
 	case "teraType":
 	case "teraToggle":
 	case "item":
-		console.log(className);
 		var id = $(this).closest(".poke-info").prop("id");
 		var terrainValue = $("input:checkbox[name='terrain']:checked").val();
 		if (terrainValue === "Electric") {

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -445,6 +445,7 @@ $(".set-selector").change(function () {
 		pokeObj.find(".analysis").attr("href", smogonAnalysis(pokemonName));
 		pokeObj.find(".type1").val(pokemon.types[0]);
 		pokeObj.find(".type2").val(pokemon.types[1]);
+		pokeObj.find(".teraType").val(pokemon.teraType || pokemon.types[0]);
 		pokeObj.find(".hp .base").val(pokemon.bs.hp);
 		var i;
 		for (i = 0; i < LEGACY_STATS[gen].length; i++) {
@@ -619,6 +620,7 @@ $(".forme").change(function () {
 
 	$(this).parent().siblings().find(".type1").val(altForme.types[0]);
 	$(this).parent().siblings().find(".type2").val(altForme.types[1] ? altForme.types[1] : "");
+	$(this).parent().siblings().find(".teraType").val(altForme.types[0]);
 	for (var i = 0; i < LEGACY_STATS[9].length; i++) {
 		var baseStat = container.find("." + LEGACY_STATS[9][i]).find(".base");
 		baseStat.val(altForme.bs[LEGACY_STATS[9][i]]);
@@ -761,6 +763,7 @@ function createPokemon(pokeInfo) {
 		var ability = pokeInfo.find(".ability").val();
 		var item = pokeInfo.find(".item").val();
 		var isDynamaxed = pokeInfo.find(".max").prop("checked");
+		var teraType = pokeInfo.find(".teraToggle").is(":checked") ? pokeInfo.find(".teraType").val() : undefined;
 		pokeInfo.isDynamaxed = isDynamaxed;
 		calcHP(pokeInfo);
 		var curHP = ~~pokeInfo.find(".current-hp").val();
@@ -777,6 +780,7 @@ function createPokemon(pokeInfo) {
 			ivs: ivs,
 			evs: evs,
 			isDynamaxed: isDynamaxed,
+			teraType: teraType,
 			boosts: boosts,
 			curHP: curHP,
 			status: CALC_STATUS[pokeInfo.find(".status").val()],
@@ -986,6 +990,7 @@ $(".gen").change(function () {
 	$(".gen-specific").not(".g" + gen).hide();
 	var typeOptions = getSelectOptions(Object.keys(typeChart));
 	$("select.type1, select.move-type").find("option").remove().end().append(typeOptions);
+	$("select.teraType").find("option").remove().end().append(getSelectOptions(Object.keys(typeChart).slice(1)));
 	$("select.type2").find("option").remove().end().append("<option value=\"\">(none)</option>" + typeOptions);
 	var moveOptions = getSelectOptions(Object.keys(moves), true);
 	$("select.move-selector").find("option").remove().end().append(moveOptions);
@@ -1150,9 +1155,10 @@ var stickyMoves = (function () {
 })();
 
 function isPokeInfoGrounded(pokeInfo) {
+	var teraType = pokeInfo.find(".teraToggle").is(":checked") ? pokeInfo.find(".teraType").val() : undefined;
 	return $("#gravity").prop("checked") || (
-		pokeInfo.find(".type1").val() !== "Flying" &&
-        pokeInfo.find(".type2").val() !== "Flying" &&
+		  teraType ? teraType !== "Flying" : pokeInfo.find(".type1").val() !== "Flying" &&
+        teraType ? teraType !== "Flying" : pokeInfo.find(".type2").val() !== "Flying" &&
         pokeInfo.find(".ability").val() !== "Levitate" &&
         pokeInfo.find(".item").val() !== "Air Balloon"
 	);
@@ -1164,7 +1170,10 @@ function getTerrainEffects() {
 	switch (className) {
 	case "type1":
 	case "type2":
+	case "teraType":
+	case "teraToggle":
 	case "item":
+		console.log(className);
 		var id = $(this).closest(".poke-info").prop("id");
 		var terrainValue = $("input:checkbox[name='terrain']:checked").val();
 		if (terrainValue === "Electric") {


### PR DESCRIPTION
- Adds a checkbox for Terastall types
- Allow importing sets with tera types
- Fixes a bug where `Pokemon#hasType` would not return the tera type but the original leading to bugs like Flying Iron Hands taking reduced damage from Outrage in Misty Terrain. I'm not sure if there are any negative ramifications from this change. @DaWoblefet - are there any interactions where the Pokemon's tera type is ignored?