### PR TITLE
Gens 1-2: If damage is 1, skip random factor

### DIFF
--- a/calc/src/mechanics/gen12.ts
+++ b/calc/src/mechanics/gen12.ts
@@ -213,10 +213,10 @@ export function calculateRBYGSC(
 
   result.damage = [];
   for (let i = 217; i <= 255; i++) {
-    if (gen.num === 2) {
+    if (gen.num === 2) { //in gen 2 damage is always rounded up to 1. TODO ADD TESTS
       result.damage[i - 217] = Math.max(1, Math.floor((baseDamage * i) / 255));
     } else {
-      if (baseDamage === 1) {
+      if (baseDamage === 1) { //in gen 1 the random factor multiplication is skipped if damage = 1
         result.damage[i - 217] = 1;
       } else {
         result.damage[i - 217] = Math.floor((baseDamage * i) / 255);

--- a/calc/src/mechanics/gen12.ts
+++ b/calc/src/mechanics/gen12.ts
@@ -213,10 +213,14 @@ export function calculateRBYGSC(
 
   result.damage = [];
   for (let i = 217; i <= 255; i++) {
-    if (baseDamage === 1) {
-      result.damage[i - 217] = 1;
+    if (gen.num === 2) {
+      result.damage[i - 217] = Math.max(1, Math.floor((baseDamage * i) / 255));
     } else {
-      result.damage[i - 217] = Math.floor((baseDamage * i) / 255);
+      if (baseDamage === 1) {
+        result.damage[i - 217] = 1;
+      } else {
+        result.damage[i - 217] = Math.floor((baseDamage * i) / 255);
+      }
     }
   }
 

--- a/calc/src/mechanics/gen12.ts
+++ b/calc/src/mechanics/gen12.ts
@@ -213,10 +213,10 @@ export function calculateRBYGSC(
 
   result.damage = [];
   for (let i = 217; i <= 255; i++) {
-    if (gen.num === 2) { //in gen 2 damage is always rounded up to 1. TODO ADD TESTS
+    if (gen.num === 2) { // in gen 2 damage is always rounded up to 1. TODO ADD TESTS
       result.damage[i - 217] = Math.max(1, Math.floor((baseDamage * i) / 255));
     } else {
-      if (baseDamage === 1) { //in gen 1 the random factor multiplication is skipped if damage = 1
+      if (baseDamage === 1) { // in gen 1 the random factor multiplication is skipped if damage = 1
         result.damage[i - 217] = 1;
       } else {
         result.damage[i - 217] = Math.floor((baseDamage * i) / 255);

--- a/calc/src/mechanics/gen12.ts
+++ b/calc/src/mechanics/gen12.ts
@@ -213,7 +213,11 @@ export function calculateRBYGSC(
 
   result.damage = [];
   for (let i = 217; i <= 255; i++) {
-    result.damage[i - 217] = Math.floor((baseDamage * i) / 255);
+    if (baseDamage === 1) {
+      result.damage[i - 217] = 1;
+    } else {
+      result.damage[i - 217] = Math.floor((baseDamage * i) / 255);
+    }
   }
 
   return result;


### PR DESCRIPTION
In Gen 1, the random factor multiplication should be skipped if the damage at that point is 1. In Gen 2, the final damage is rounded up to 1 if it is 0.

This is implemented in PS.

Deals with the issue: https://github.com/smogon/damage-calc/issues/511