### PR TITLE
Fix check for moves receiving a BP increase due to Tera

### DIFF
--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -814,7 +814,7 @@ export function calculateBasePowerSMSSSV(
   if (
     attacker.teraType && move.type === attacker.teraType &&
     attacker.hasType(attacker.teraType) && move.hits === 1 &&
-    move.priority <= 0 && move.bp > 0 && move.named("Dragon Energy", "Eruption", "Water Spout") &&
+    move.priority <= 0 && move.bp > 0 && !move.named('Dragon Energy', 'Eruption', 'Water Spout') &&
     basePower < 60 && gen.num >= 9
   ) {
     basePower = 60;

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -813,10 +813,12 @@ export function calculateBasePowerSMSSSV(
   basePower = OF16(Math.max(1, pokeRound((basePower * chainMods(bpMods, 41, 2097152)) / 4096)));
   if (
     attacker.teraType && move.type === attacker.teraType &&
-    attacker.hasType(attacker.teraType) && !move.hits &&
-    move.priority <= 0 && basePower <= 60 && gen.num >= 9
+    attacker.hasType(attacker.teraType) && move.hits === 1 &&
+    move.priority <= 0 && move.bp > 0 && move.named("Dragon Energy", "Eruption", "Water Spout") &&
+    basePower < 60 && gen.num >= 9
   ) {
     basePower = 60;
+    desc.moveBP = 60;
   }
   return basePower;
 }


### PR DESCRIPTION
Addresses the issue listed [here](https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/post-9460009). Also added a check which should prevent the moves listed [here](https://www.serebii.net/scarletviolet/terastal.shtml) from being upped to 60 BP. This check also prevents Wring Out and Punishment (which do not exist in Gen 9 games) from receiving a BP increase, but that should line up with the behavior exhibited by the simulator in National Dex.

Also added `(60 BP)` to the description whenever this behavior occurs.

(This is my first pull request, so I apologize if there any courtesies that I am unaware of)