### PR TITLE
Add type effectiveness precedence for Gen 2, 3, and 4

### DIFF
--- a/calc/src/mechanics/gen12.ts
+++ b/calc/src/mechanics/gen12.ts
@@ -66,18 +66,11 @@ export function calculateRBYGSC(
   let secondDefenderType = defender.types[1];
 
   if (secondDefenderType && firstDefenderType !== secondDefenderType && gen.num === 2) {
-    if (move.type === 'Ice' && (firstDefenderType === 'Fire' || secondDefenderType === 'Fire')) {
-      if (firstDefenderType === 'Fire') {
-        firstDefenderType = secondDefenderType;
-        secondDefenderType = 'Fire';
-      }
-    } else {
       const firstTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(firstDefenderType);
       const secondTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(secondDefenderType);
 
       if (firstTypePrecedence > secondTypePrecedence) {
         [firstDefenderType, secondDefenderType] = [secondDefenderType, firstDefenderType];
-      }
     }
   }
 

--- a/calc/src/mechanics/gen12.ts
+++ b/calc/src/mechanics/gen12.ts
@@ -1,4 +1,4 @@
-import {Generation, TypeName} from '../data/interface';
+import {Generation} from '../data/interface';
 import {getItemBoostType} from '../items';
 import {RawDesc} from '../desc';
 import {Field} from '../field';

--- a/calc/src/mechanics/gen12.ts
+++ b/calc/src/mechanics/gen12.ts
@@ -1,4 +1,4 @@
-import {Generation} from '../data/interface';
+import {Generation, TypeName} from '../data/interface';
 import {getItemBoostType} from '../items';
 import {RawDesc} from '../desc';
 import {Field} from '../field';
@@ -42,10 +42,50 @@ export function calculateRBYGSC(
     }
   }
 
+  const typeEffectivenessPrecedenceRules = [
+    'Normal',
+    'Fire',
+    'Water',
+    'Electric',
+    'Grass',
+    'Ice',
+    'Fighting',
+    'Poison',
+    'Ground',
+    'Flying',
+    'Psychic',
+    'Bug',
+    'Rock',
+    'Ghost',
+    'Dragon',
+    'Dark',
+    'Steel',
+  ];
+
+  let firstDefenderType = defender.types[0];
+  let secondDefenderType = defender.types[1];
+
+  if (secondDefenderType && firstDefenderType !== secondDefenderType && gen.num === 2) {
+    if (move.type === 'Ice' && (firstDefenderType === 'Fire' || secondDefenderType === 'Fire')) {
+      if (firstDefenderType === 'Fire') {
+        firstDefenderType = secondDefenderType;
+        secondDefenderType = 'Fire';
+      }
+    } else {
+      const firstTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(firstDefenderType);
+      const secondTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(secondDefenderType);
+
+      if (firstTypePrecedence > secondTypePrecedence) {
+        [firstDefenderType, secondDefenderType] = [secondDefenderType, firstDefenderType];
+      }
+    }
+  }
+
+
   const type1Effectiveness =
-    getMoveEffectiveness(gen, move, defender.types[0], field.defenderSide.isForesight);
-  const type2Effectiveness = defender.types[1]
-    ? getMoveEffectiveness(gen, move, defender.types[1], field.defenderSide.isForesight)
+    getMoveEffectiveness(gen, move, firstDefenderType, field.defenderSide.isForesight);
+  const type2Effectiveness = secondDefenderType
+    ? getMoveEffectiveness(gen, move, secondDefenderType, field.defenderSide.isForesight)
     : 1;
   const typeEffectiveness = type1Effectiveness * type2Effectiveness;
 

--- a/calc/src/mechanics/gen12.ts
+++ b/calc/src/mechanics/gen12.ts
@@ -66,11 +66,11 @@ export function calculateRBYGSC(
   let secondDefenderType = defender.types[1];
 
   if (secondDefenderType && firstDefenderType !== secondDefenderType && gen.num === 2) {
-      const firstTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(firstDefenderType);
-      const secondTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(secondDefenderType);
+    const firstTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(firstDefenderType);
+    const secondTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(secondDefenderType);
 
-      if (firstTypePrecedence > secondTypePrecedence) {
-        [firstDefenderType, secondDefenderType] = [secondDefenderType, firstDefenderType];
+    if (firstTypePrecedence > secondTypePrecedence) {
+      [firstDefenderType, secondDefenderType] = [secondDefenderType, firstDefenderType];
     }
   }
 

--- a/calc/src/mechanics/gen3.ts
+++ b/calc/src/mechanics/gen3.ts
@@ -86,12 +86,6 @@ export function calculateADV(
   let secondDefenderType = defender.types[1];
 
   if (secondDefenderType && firstDefenderType !== secondDefenderType) {
-    if (move.type === 'Ice' && (firstDefenderType === 'Fire' || secondDefenderType === 'Fire')) {
-      if (firstDefenderType === 'Fire') {
-        firstDefenderType = secondDefenderType;
-        secondDefenderType = 'Fire';
-      }
-    } else {
       const firstTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(firstDefenderType);
       const secondTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(secondDefenderType);
 

--- a/calc/src/mechanics/gen3.ts
+++ b/calc/src/mechanics/gen3.ts
@@ -62,14 +62,53 @@ export function calculateADV(
     desc.moveBP = move.bp;
   }
 
+  const typeEffectivenessPrecedenceRules = [
+    'Normal',
+    'Fire',
+    'Water',
+    'Electric',
+    'Grass',
+    'Ice',
+    'Fighting',
+    'Poison',
+    'Ground',
+    'Flying',
+    'Psychic',
+    'Bug',
+    'Rock',
+    'Ghost',
+    'Dragon',
+    'Dark',
+    'Steel',
+  ];
+
+  let firstDefenderType = defender.types[0];
+  let secondDefenderType = defender.types[1];
+
+  if (secondDefenderType && firstDefenderType !== secondDefenderType) {
+    if (move.type === 'Ice' && (firstDefenderType === 'Fire' || secondDefenderType === 'Fire')) {
+      if (firstDefenderType === 'Fire') {
+        firstDefenderType = secondDefenderType;
+        secondDefenderType = 'Fire';
+      }
+    } else {
+      const firstTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(firstDefenderType);
+      const secondTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(secondDefenderType);
+
+      if (firstTypePrecedence > secondTypePrecedence) {
+        [firstDefenderType, secondDefenderType] = [secondDefenderType, firstDefenderType];
+      }
+    }
+  }
+
   const type1Effectiveness = getMoveEffectiveness(
     gen,
     move,
-    defender.types[0],
+    firstDefenderType,
     field.defenderSide.isForesight
   );
-  const type2Effectiveness = defender.types[1]
-    ? getMoveEffectiveness(gen, move, defender.types[1], field.defenderSide.isForesight)
+  const type2Effectiveness = secondDefenderType
+    ? getMoveEffectiveness(gen, move, secondDefenderType, field.defenderSide.isForesight)
     : 1;
   const typeEffectiveness = type1Effectiveness * type2Effectiveness;
 

--- a/calc/src/mechanics/gen3.ts
+++ b/calc/src/mechanics/gen3.ts
@@ -86,12 +86,11 @@ export function calculateADV(
   let secondDefenderType = defender.types[1];
 
   if (secondDefenderType && firstDefenderType !== secondDefenderType) {
-      const firstTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(firstDefenderType);
-      const secondTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(secondDefenderType);
+    const firstTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(firstDefenderType);
+    const secondTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(secondDefenderType);
 
-      if (firstTypePrecedence > secondTypePrecedence) {
-        [firstDefenderType, secondDefenderType] = [secondDefenderType, firstDefenderType];
-      }
+    if (firstTypePrecedence > secondTypePrecedence) {
+      [firstDefenderType, secondDefenderType] = [secondDefenderType, firstDefenderType];
     }
   }
 

--- a/calc/src/mechanics/gen4.ts
+++ b/calc/src/mechanics/gen4.ts
@@ -103,10 +103,50 @@ export function calculateDPP(
   }
 
   const isGhostRevealed = attacker.hasAbility('Scrappy') || field.defenderSide.isForesight;
+
+  const typeEffectivenessPrecedenceRules = [
+    'Normal',
+    'Fire',
+    'Water',
+    'Electric',
+    'Grass',
+    'Ice',
+    'Fighting',
+    'Poison',
+    'Ground',
+    'Flying',
+    'Psychic',
+    'Bug',
+    'Rock',
+    'Ghost',
+    'Dragon',
+    'Dark',
+    'Steel',
+  ];
+
+  let firstDefenderType = defender.types[0];
+  let secondDefenderType = defender.types[1];
+
+  if (secondDefenderType && firstDefenderType !== secondDefenderType) {
+    if (move.type === 'Ice' && (firstDefenderType === 'Fire' || secondDefenderType === 'Fire')) {
+      if (firstDefenderType === 'Fire') {
+        firstDefenderType = secondDefenderType;
+        secondDefenderType = 'Fire';
+      }
+    } else {
+      const firstTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(firstDefenderType);
+      const secondTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(secondDefenderType);
+
+      if (firstTypePrecedence > secondTypePrecedence) {
+        [firstDefenderType, secondDefenderType] = [secondDefenderType, firstDefenderType];
+      }
+    }
+  }
+
   let type1Effectiveness =
-    getMoveEffectiveness(gen, move, defender.types[0], isGhostRevealed, field.isGravity);
-  let type2Effectiveness = defender.types[1]
-    ? getMoveEffectiveness(gen, move, defender.types[1], isGhostRevealed, field.isGravity)
+    getMoveEffectiveness(gen, move, firstDefenderType, isGhostRevealed, field.isGravity);
+  let type2Effectiveness = secondDefenderType
+    ? getMoveEffectiveness(gen, move, secondDefenderType, isGhostRevealed, field.isGravity)
     : 1;
 
   let typeEffectiveness = type1Effectiveness * type2Effectiveness;

--- a/calc/src/mechanics/gen4.ts
+++ b/calc/src/mechanics/gen4.ts
@@ -128,18 +128,10 @@ export function calculateDPP(
   let secondDefenderType = defender.types[1];
 
   if (secondDefenderType && firstDefenderType !== secondDefenderType) {
-    if (move.type === 'Ice' && (firstDefenderType === 'Fire' || secondDefenderType === 'Fire')) {
-      if (firstDefenderType === 'Fire') {
-        firstDefenderType = secondDefenderType;
-        secondDefenderType = 'Fire';
-      }
-    } else {
-      const firstTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(firstDefenderType);
-      const secondTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(secondDefenderType);
-
-      if (firstTypePrecedence > secondTypePrecedence) {
-        [firstDefenderType, secondDefenderType] = [secondDefenderType, firstDefenderType];
-      }
+    const firstTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(firstDefenderType);
+    const secondTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(secondDefenderType);
+    if (firstTypePrecedence > secondTypePrecedence) {
+      [firstDefenderType, secondDefenderType] = [secondDefenderType, firstDefenderType];
     }
   }
 

--- a/calc/src/mechanics/gen4.ts
+++ b/calc/src/mechanics/gen4.ts
@@ -130,6 +130,7 @@ export function calculateDPP(
   if (secondDefenderType && firstDefenderType !== secondDefenderType) {
     const firstTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(firstDefenderType);
     const secondTypePrecedence = typeEffectivenessPrecedenceRules.indexOf(secondDefenderType);
+
     if (firstTypePrecedence > secondTypePrecedence) {
       [firstDefenderType, secondDefenderType] = [secondDefenderType, firstDefenderType];
     }


### PR DESCRIPTION
In Gen 2, 3, and 4, when it comes to calculating the damage based on dual type effectiveness, the defensive types are reordered according to a fixed order. This can alter rounding for the computed damage, since type effectiveness multiplications are performed for each type separately.

```
[
    'Normal',
    'Fire',
    'Water',
    'Electric',
    'Grass',
    'Ice',
    'Fighting',
    'Poison',
    'Ground',
    'Flying',
    'Psychic',
    'Bug',
    'Rock',
    'Ghost',
    'Dragon',
    'Dark',
    'Steel',
]
```

This array determines the type order. For example if the defending type is Type 1 = Rock, Type 2 = Ground, the game will swap them for type effectiveness matters.

However, there is an exception when the attacking type is Ice and one of the defending types if Fire. In that case, Fire will always become the second defensive type.

(We have noticed and confirmed this thanks to speedruns of HGSS)