### PR TITLE
Implement Ability Shield

### DIFF
--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -125,7 +125,11 @@ export function calculateSMSSSV(
   if (!defenderIgnoresAbility && !defender.hasAbility('Poison Heal') &&
     (attackerIgnoresAbility || moveIgnoresAbility)) {
     if (attackerIgnoresAbility) desc.attackerAbility = attacker.ability;
-    defender.ability = '' as AbilityName;
+    if (defender.hasItem('Ability Shield')) {
+      desc.defenderItem = defender.item;
+    } else {
+      defender.ability = '' as AbilityName;
+    }
   }
 
   // Merciless does not ignore Shell Armor, damage dealt to a poisoned Pokemon with Shell Armor

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -122,14 +122,10 @@ export function calculateSMSSSV(
     'Searing Sunraze Smash',
     'Sunsteel Strike'
   );
-  if (!defenderIgnoresAbility && !defender.hasAbility('Poison Heal')) {
-    if (attackerIgnoresAbility) {
-      defender.ability = '' as AbilityName;
-      desc.attackerAbility = attacker.ability;
-    }
-    if (moveIgnoresAbility) {
-      defender.ability = '' as AbilityName;
-    }
+  if (!defenderIgnoresAbility && !defender.hasAbility('Poison Heal') &&
+    (attackerIgnoresAbility || moveIgnoresAbility)) {
+    if (attackerIgnoresAbility) desc.attackerAbility = attacker.ability;
+    defender.ability = '' as AbilityName;
   }
 
   // Merciless does not ignore Shell Armor, damage dealt to a poisoned Pokemon with Shell Armor


### PR DESCRIPTION
Under this implementation, if the ability is a Mold Breaker ability, it will still be shown even as it is ignored, and the Ability Shield will also be shown.