### PR TITLE
Fix Collision Course/Electro Drift

### DIFF
--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -890,18 +890,24 @@ export function calculateBPModsSMSSSV(
       attacker.hasAbility('Scrappy') || field.defenderSide.isForesight;
     const isRingTarget =
       defender.hasItem('Ring Target') && !defender.hasAbility('Klutz');
-    let effectiveness = 1;
-    for (const type of defender.teraType ? [defender.teraType] : defender.types) {
-      effectiveness *= getMoveEffectiveness(
-        gen,
-        move,
-        type,
-        isGhostRevealed,
-        field.isGravity,
-        isRingTarget
-      );
-    }
-    if (effectiveness >= 2) {
+    const types = defender.teraType ? [defender.teraType] : defender.types;
+    const type1Effectiveness = getMoveEffectiveness(
+      gen,
+      move,
+      types[0],
+      isGhostRevealed,
+      field.isGravity,
+      isRingTarget
+    );
+    const type2Effectiveness = types[1] ? getMoveEffectiveness(
+      gen,
+      move,
+      types[0],
+      isGhostRevealed,
+      field.isGravity,
+      isRingTarget
+    ) : 1;
+    if (type1Effectiveness * type2Effectiveness >= 2) {
       bpMods.push(5461);
       desc.moveBP = basePower * (5461 / 4096);
     }

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -890,23 +890,18 @@ export function calculateBPModsSMSSSV(
       attacker.hasAbility('Scrappy') || field.defenderSide.isForesight;
     const isRingTarget =
       defender.hasItem('Ring Target') && !defender.hasAbility('Klutz');
-    const type1Effectiveness = getMoveEffectiveness(
-      gen,
-      move,
-      defender.types[0],
-      isGhostRevealed,
-      field.isGravity,
-      isRingTarget
-    );
-    const type2Effectiveness = defender.types[1] ? getMoveEffectiveness(
-      gen,
-      move,
-      defender.types[0],
-      isGhostRevealed,
-      field.isGravity,
-      isRingTarget
-    ) : 1;
-    if (type1Effectiveness * type2Effectiveness >= 2) {
+    let effectiveness = 1;
+    for (const type of defender.teraType ? [defender.teraType] : defender.types) {
+      effectiveness *= getMoveEffectiveness(
+        gen,
+        move,
+        type,
+        isGhostRevealed,
+        field.isGravity,
+        isRingTarget
+      );
+    }
+    if (effectiveness >= 2) {
       bpMods.push(5461);
       desc.moveBP = basePower * (5461 / 4096);
     }

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -902,7 +902,7 @@ export function calculateBPModsSMSSSV(
     const type2Effectiveness = types[1] ? getMoveEffectiveness(
       gen,
       move,
-      types[0],
+      types[1],
       isGhostRevealed,
       field.isGravity,
       isRingTarget

--- a/calc/src/test/calc.test.ts
+++ b/calc/src/test/calc.test.ts
@@ -927,6 +927,30 @@ describe('calc', () => {
             '0 Atk Supreme Overlord 5 allies fainted Kingambit Iron Head vs. 0 HP / 0 Def Aggron: 100-118 (35.5 - 41.9%) -- guaranteed 3HKO'
           );
         });
+        test('Electro Drift/Collision Course boost on Super Effective hits', () => {
+          const attacker = Pokemon('Arceus'); // same stats in each offense, does not get stab on fighting or electric
+          let defender = Pokemon('Mew'); // neutral to both
+          const calc = (move = Move('Electro Drift')) => calculate(attacker, defender, move).range();
+          // 1x effectiveness should be identical to just using a 100 BP move
+          const neutral = calc();
+          const fusionBolt = Move('Fusion Bolt');
+          expect(calc(fusionBolt)).toEqual(neutral);
+          // 2x effectiveness
+          defender = Pokemon('Manaphy');
+          const se = calc();
+          // expect some sort of boost compared to the control
+          expect(calc(fusionBolt)).not.toEqual(se);
+          // tera should be able to revoke the boost
+          defender.teraType = 'Normal';
+          expect(calc()).toEqual(neutral);
+          // check if secondary type resist is handled
+          const cc = Move('Collision Course'); // Fighting type
+          defender = Pokemon('Jirachi'); // Steel / Psychic is neutral to fighting, so no boost
+          expect(calc(cc)).toEqual(neutral);
+          // tera should cause the boost to be applied
+          defender.teraType = 'Normal';
+          expect(calc(cc)).toEqual(se);
+        });
       });
     });
   });


### PR DESCRIPTION
Tera type is now used instead of actual type if provided, fixing a bug where Collision Course gave its boost when supereffective against the original type.