### PR TITLE
Show (and use) EVs in the calculator for Gen 1/2

### DIFF
--- a/calc/src/stats.ts
+++ b/calc/src/stats.ts
@@ -159,9 +159,9 @@ export const Stats = new (class {
 
   calcStatRBYFromDV(stat: StatID, base: number, dv: number, level: number) {
     if (stat === 'hp') {
-      return Math.floor((((base + dv) * 2 + 63) * level) / 100) + level + 10;
+      return Math.floor((((base + dv) * 2 + Math.floor(ev / 4)) * level) / 100) + level + 10;
     } else {
-      return Math.floor((((base + dv) * 2 + 63) * level) / 100) + 5;
+      return Math.floor((((base + dv) * 2 + Math.floor(ev / 4)) * level) / 100) + 5;
     }
   }
 

--- a/src/honkalculate.template.html
+++ b/src/honkalculate.template.html
@@ -117,7 +117,7 @@
                                 <th></th>
                                 <th>Base</th>
                                 <th class="gen-specific g3 g4 g5 g6 g7 g8 g9">IVs</th>
-                                <th class="gen-specific g3 g4 g5 g6 g7 g8 g9">EVs</th>
+                                <th class="gen-specific g1 g2 g3 g4 g5 g6 g7 g8 g9">EVs</th>
                                 <th class="gen-specific g1 g2 hide">DVs</th>
                                 <th></th>
                                 <th></th>
@@ -138,6 +138,9 @@
                                 <td class="gen-specific g1 g2 hide">
                                     <input class="dvs" value="15" disabled="disabled" />
                                 </td>
+										  <td class="gen-specific g1 g2 hide">
+                                    <input class="evs" type="number" min="0" max="252" step="4" value="252" />
+                                </td>
                                 <td><span class="total">341</span>
                                 </td>
                                 <td></td>
@@ -157,6 +160,9 @@
                                 </td>
                                 <td class="gen-specific g1 g2 hide">
                                     <input class="dvs" value="15" />
+                                </td>
+										  <td class="gen-specific g1 g2 hide">
+                                    <input class="evs" type="number" min="0" max="252" step="4" value="252" />
                                 </td>
                                 <td><span class="total">236</span>
                                 </td>
@@ -194,6 +200,9 @@
                                 <td class="gen-specific g1 g2 hide">
                                     <input class="dvs" value="15" />
                                 </td>
+										  <td class="gen-specific g1 g2 hide">
+                                    <input class="evs" type="number" min="0" max="252" step="4" value="252" />
+                                </td>
                                 <td><span class="total">236</span>
                                 </td>
                                 <td>
@@ -229,6 +238,9 @@
                                 </td>
                                 <td class="gen-specific g1 g2 hide">
                                     <input class="dvs" value="15" />
+                                </td>
+										  <td class="gen-specific g2 hide">
+                                    <input class="evs" type="number" min="0" max="252" step="4" value="252" />
                                 </td>
                                 <td><span class="total">236</span>
                                 </td>
@@ -266,6 +278,9 @@
                                 <td class="gen-specific g1 g2 hide">
                                     <input class="dvs" value="15" disabled="disabled" />
                                 </td>
+										  <td class="gen-specific g2 hide">
+                                    <input class="evs" type="number" min="0" max="252" step="4" value="252" />
+                                </td>
                                 <td><span class="total">236</span>
                                 </td>
                                 <td>
@@ -292,6 +307,9 @@
                                 </td>
                                 <td>
                                     <input class="base" value="100" />
+                                </td>
+										  <td>
+                                    <input class="evs" type="number" min="0" max="252" step="4" value="252" />
                                 </td>
                                 <td>
                                     <input class="dvs" value="15" />
@@ -331,6 +349,9 @@
                                 </td>
                                 <td class="gen-specific g1 g2 hide">
                                     <input class="dvs" value="15" />
+                                </td>
+										  <td class="gen-specific g1 g2 hide">
+                                    <input class="evs" type="number" min="0" max="252" step="4" value="252" />
                                 </td>
                                 <td><span class="total">236</span>
                                 </td>

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -171,7 +171,7 @@
                             <th></th>
                             <th scope="col">Base</th>
                             <th class="gen-specific g3 g4 g5 g6 g7 g8 g9" scope="col">IVs</th>
-                            <th class="gen-specific g3 g4 g5 g6 g7 g8 g9" scope="col">EVs</th>
+                            <th class="gen-specific g1 g2 g3 g4 g5 g6 g7 g8 g9" scope="col">EVs</th>
                             <th class="gen-specific g1 g2 hide" scope="col">DVs</th>
                             <th></th>
                             <th></th>
@@ -194,6 +194,9 @@
                             <td class="gen-specific g1 g2 hide">
                                 <input class="dvs calc-trigger" value="15" disabled="disabled" />
                             </td>
+									 <td class="gen-specific g1 g2 hide">
+                                <input class="evs" type="number" min="0" max="252" step="4" value="252" />
+                            </td>
                             <td><span class="total">341</span>
                             </td>
                             <td></td>
@@ -213,6 +216,9 @@
                             </td>
                             <td class="gen-specific g1 g2 hide">
                                 <input class="dvs calc-trigger" value="15" />
+                            </td>
+									 <td class="gen-specific g1 g2 hide">
+                                <input class="evs" type="number" min="0" max="252" step="4" value="252" />
                             </td>
                             <td><span class="total">236</span>
                             </td>
@@ -250,6 +256,9 @@
                             <td class="gen-specific g1 g2 hide">
                                 <input class="dvs calc-trigger" value="15" />
                             </td>
+									 <td class="gen-specific g1 g2 hide">
+                                <input class="evs" type="number" min="0" max="252" step="4" value="252" />
+                            </td>
                             <td><span class="total">236</span>
                             </td>
                             <td>
@@ -285,6 +294,9 @@
                             </td>
                             <td class="gen-specific g1 g2 hide">
                                 <input class="dvs calc-trigger" value="15" />
+                            </td>
+									 <td class="gen-specific g2 hide">
+                                <input class="evs" type="number" min="0" max="252" step="4" value="252" />
                             </td>
                             <td><span class="total">236</span>
                             </td>
@@ -322,6 +334,9 @@
                             <td class="gen-specific g1 g2 hide">
                                 <input class="dvs calc-trigger" value="15" disabled="disabled" />
                             </td>
+									 <td class="gen-specific g2 hide">
+                                <input class="evs" type="number" min="0" max="252" step="4" value="252" />
+                            </td>
                             <td><span class="total">236</span>
                             </td>
                             <td>
@@ -351,6 +366,9 @@
                             </td>
                             <td>
                                 <input class="dvs calc-trigger" value="15" />
+                            </td>
+									 <td>
+                                <input class="evs" type="number" min="0" max="252" step="4" value="252" />
                             </td>
                             <td><span class="total">236</span>
                             </td>
@@ -387,6 +405,9 @@
                             </td>
                             <td class="gen-specific g1 g2 hide">
                                 <input class="dvs calc-trigger" value="15" />
+                            </td>
+									 <td class="gen-specific g1 g2 hide">
+                                <input class="evs" type="number" min="0" max="252" step="4" value="252" />
                             </td>
                             <td><span class="total">236</span>
                             </td>

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -985,7 +985,7 @@ function calcStat(poke, StatID) {
 	var nature, ivs, evs;
 	if (gen < 3) {
 		ivs = ~~stat.find(".dvs").val() * 2;
-		evs = 252;
+		evs = ~~stat.find(".evs").val();
 	} else {
 		ivs = ~~stat.find(".ivs").val();
 		evs = ~~stat.find(".evs").val();


### PR DESCRIPTION
As per my post on Smogon: 
"Small thing but could we please have EVs shown on calc for gens 1-2? This is actually relevant for some calcs - for example in gen 1 "Safetwo" (immune to overflow) uses 341 special, not 406, which is literally impossible to set in the calc without Stat EXP/EVs, and a lot of Counter techs require lower stats than just dropping the DV to 1. Editing base stats is often a little inaccurate and is super inconvenient since it resets every time you change mons. Just showing it and defaulting all sets to max in all stats would help a lot."

I attempted to: 1. Remove the automatic +63 replacing EVs for gen1/2 and use the same EV function as gen3+, 2. make the calc check EV value for gen1/2 rather than sub in 252, 3. make the EV UI show in gen1/2, and 4. default EVs to 252 for blank imports rather than 0 like later gens since most Pokemon will use max stats in gen 1/2. I am especially unsure I did that last part right.

I am not a coder and cannot promise this is even a functional fix but I tried to read through the files and ensure I didn't miss anything. I also have never used GitHub so sorry if I did something wrong with the updates/pull request, I'm playing this by ear. Hopefully it's either semi-functional or a springboard for someone else to add EVs to the calc in a better way. Thanks for reading!