### PR TITLE
[@smogon/calc] Speed up npm test script

### DIFF
--- a/calc/package.json
+++ b/calc/package.json
@@ -34,7 +34,6 @@
     "test": "jest",
     "coverage": "jest --coverage",
     "prepare": "npm run build",
-    "pretest": "npm run build",
     "posttest": "npm run lint"
   }
 }


### PR DESCRIPTION
I suspect this wasn't always the case, but `npm test` no longer depends on compiled artifacts.

Since that's the case, there's no need to run the compiler before every test run.  Removing this build step speeds up the development + testing loop significantly!