### PR TITLE
Remove misleading KO chance outputs

### DIFF
--- a/calc/src/desc.ts
+++ b/calc/src/desc.ts
@@ -291,20 +291,28 @@ export function getKOChance(
       ? ' after ' + serializeText(hazards.texts.concat(eot.texts))
       : '';
 
+  function KOChance(
+    chance: number | undefined,
+    n: number,
+    multipleTurns = false,
+  ) {
+    if (chance === 0) return {chance: undefined, n, text: qualifier + 'not a KO'};
+    let text = chance === undefined ? qualifier + 'possible '
+      : chance === 1 ? qualifier || 'guaranteed '
+      // prevent displaying misleading 100% or 0% chances
+      : `${qualifier}${Math.round(chance * 1000) / 10}% chance to `;
+    // using the number of hits we can determine the type of KO we are checking for
+    text += n === 1 ? 'OHKO' + hazardsText
+      : (multipleTurns ? `KO in ${n} turns` : `${n}HKO`) + afterText;
+    return {chance, n, text};
+  }
+
   if ((move.timesUsed === 1 && move.timesUsedWithMetronome === 1) || move.isZ) {
     const chance = computeKOChance(
       damage, defender.curHP() - hazards.damage, 0, 1, 1, defender.maxHP(), toxicCounter
     );
-    if (chance === 1) {
-      return {chance, n: 1, text: `guaranteed OHKO${hazardsText}`}; // eot wasn't considered
-    } else if (chance > 0) {
-      // note: still not accounting for EOT due to poor eot damage handling
-      return {
-        chance,
-        n: 1,
-        text: qualifier + Math.round(chance * 1000) / 10 + `% chance to OHKO${hazardsText}`,
-      };
-    }
+    // note: still not accounting for EOT due to poor eot damage handling
+    if (chance > 0) return KOChance(chance, 1);
 
     // Parental Bond's combined first + second hit only is accurate for chance to OHKO, for
     // multihit KOs its only approximated. We should be doing squashMultihit here instead of
@@ -319,15 +327,7 @@ export function getKOChance(
       const chance = computeKOChance(
         damage, defender.curHP() - hazards.damage, eot.damage, i, 1, defender.maxHP(), toxicCounter
       );
-      if (chance === 1) {
-        return {chance, n: i, text: `${qualifier || 'guaranteed '}${i}HKO${afterText}`};
-      } else if (chance > 0) {
-        return {
-          chance,
-          n: i,
-          text: qualifier + Math.round(chance * 1000) / 10 + `% chance to ${i}HKO${afterText}`,
-        };
-      }
+      if (chance > 0) return KOChance(chance, i);
     }
 
     for (let i = 5; i <= 9; i++) {
@@ -335,12 +335,13 @@ export function getKOChance(
         predictTotal(damage[0], eot.damage, i, 1, toxicCounter, defender.maxHP()) >=
         defender.curHP() - hazards.damage
       ) {
-        return {chance: 1, n: i, text: `${qualifier || 'guaranteed '}${i}HKO${afterText}`};
+        return KOChance(1, i);
       } else if (
         predictTotal(damage[damage.length - 1], eot.damage, i, 1, toxicCounter, defender.maxHP()) >=
         defender.curHP() - hazards.damage
       ) {
-        return {n: i, text: qualifier + `possible ${i}HKO${afterText}`};
+        // possible but no concrete chance
+        return KOChance(undefined, i);
       }
     }
   } else {
@@ -352,22 +353,7 @@ export function getKOChance(
       defender.maxHP(),
       toxicCounter
     );
-    if (chance === 1) {
-      return {
-        chance,
-        n: move.timesUsed,
-        text: `${qualifier || 'guaranteed '}KO in ${move.timesUsed} turns${afterText}`,
-      };
-    } else if (chance > 0) {
-      return {
-        chance,
-        n: move.timesUsed,
-        text:
-          qualifier +
-          Math.round(chance * 1000) / 10 +
-          `% chance to ${move.timesUsed}HKO${afterText}`,
-      };
-    }
+    if (chance > 0) return KOChance(chance, move.timesUsed, chance === 1);
 
     if (predictTotal(
       damage[0],
@@ -379,11 +365,7 @@ export function getKOChance(
     ) >=
       defender.curHP() - hazards.damage
     ) {
-      return {
-        chance: 1,
-        n: move.timesUsed,
-        text: `${qualifier || 'guaranteed '}KO in ${move.timesUsed} turns${afterText}`,
-      };
+      return KOChance(1, move.timesUsed, true);
     } else if (
       predictTotal(
         damage[damage.length - 1],
@@ -395,12 +377,10 @@ export function getKOChance(
       ) >=
       defender.curHP() - hazards.damage
     ) {
-      return {
-        n: move.timesUsed,
-        text: qualifier + `possible KO in ${move.timesUsed} turns${afterText}`,
-      };
+      // possible but no real idea
+      return KOChance(undefined, move.timesUsed, true);
     }
-    return {n: move.timesUsed, text: qualifier + 'not a KO'};
+    return KOChance(0, move.timesUsed);
   }
 
   return {chance: 0, n: 0, text: ''};

--- a/calc/src/desc.ts
+++ b/calc/src/desc.ts
@@ -300,7 +300,7 @@ export function getKOChance(
     let text = chance === undefined ? qualifier + 'possible '
       : chance === 1 ? qualifier || 'guaranteed '
       // prevent displaying misleading 100% or 0% chances
-      : `${qualifier}${Math.round(chance * 1000) / 10}% chance to `;
+      : `${qualifier}${Math.max(Math.min(Math.round(chance * 1000), 999), 1) / 10}% chance to `;
     // using the number of hits we can determine the type of KO we are checking for
     text += n === 1 ? 'OHKO' + hazardsText
       : (multipleTurns ? `KO in ${n} turns` : `${n}HKO`) + afterText;

--- a/calc/src/test/calc.test.ts
+++ b/calc/src/test/calc.test.ts
@@ -958,5 +958,17 @@ describe('calc', () => {
         });
       });
     });
+    describe('Descriptions', () => {
+      inGen(9, ({gen, calculate, Pokemon, Move}) => {
+        test('displayed chances should not round to 100%', () => {
+          const result = calculate(
+            Pokemon('Xerneas', {item: 'Choice Band', nature: 'Adamant', evs: {atk: 252}}),
+            Pokemon('Necrozma-Dusk-Mane', {nature: 'Impish', evs: {hp: 252, def: 252}}),
+            Move('Close Combat')
+          );
+          expect(result.kochance().text).toBe('99.9% chance to 3HKO');
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
This removes a good amount of the text duplication in `getKOChance()` , but really the point is to resolve #448: where previously 100% chance to be KOed would be returned will instead yield 99.9%, and 0% will instead show 0.1%.

I also added a test for the specific case mentioned. I can't think of an example for 0%, but I have seen it before.