### PR TITLE
Fixes small error with Dark Mode

### DIFF
--- a/src/css/dark-theme.css
+++ b/src/css/dark-theme.css
@@ -114,3 +114,7 @@ td.sorting_1 {
 label:not(.btn) {
     color: white;
 }
+
+input.select2-input {
+    color: black;
+}


### PR DESCRIPTION
After dark mode was implemented (#525), I went to conduct some calcs on it within dark mode, when I saw that the dropdown inputs also had white text:

<details>
<summary>White text on white background</summary>

![Screenshot from 2023-03-30 10-57-20](https://user-images.githubusercontent.com/30420527/228879615-92efec9f-075e-45fc-bfd3-977d523a401b.png)

![Screenshot from 2023-03-30 10-59-27](https://user-images.githubusercontent.com/30420527/228879694-3c3ef84d-115b-4db8-944c-89ad24a3d979.png)

</details>

Therefore, I wrote a quick commit to make the dropdown readable again.

<details>
<summary>Black text on white background</summary>

![Screenshot from 2023-03-30 10-58-53](https://user-images.githubusercontent.com/30420527/228879983-a9d3c1d0-de7f-4919-ab41-5637057f200b.png)

![Screenshot from 2023-03-30 10-59-48](https://user-images.githubusercontent.com/30420527/228880004-4e7e04eb-9054-4be6-b4e9-a2aded4f806f.png)

</details>

This incorrect behavior does not occur in light mode.