### PR TITLE
Improvements to multi-hit moves (motivated by Population Bomb) 

### DIFF
--- a/calc/src/data/moves.ts
+++ b/calc/src/data/moves.ts
@@ -4528,7 +4528,7 @@ const SV_PATCH: {[name: string]: DeepPartial<MoveData>} = {
     maxPower: 90,
     makesContact: true,
     isSlicing: true,
-    multihit: 10,
+    multihit: [2, 10],
   },
   Pounce: {
     bp: 50,

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -542,6 +542,11 @@
                     <option value="3">3 hits</option>
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
+                    <option value="6">6 hits</option>
+                    <option value="7">7 hits</option>
+                    <option value="8">8 hits</option>
+                    <option value="9">9 hits</option>
+                    <option value="10">10 hits</option>
                 </select>
                 <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
                     <option value="1">Once</option>
@@ -576,6 +581,11 @@
                     <option value="3">3 hits</option>
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
+                    <option value="6">6 hits</option>
+                    <option value="7">7 hits</option>
+                    <option value="8">8 hits</option>
+                    <option value="9">9 hits</option>
+                    <option value="10">10 hits</option>
                 </select>
                 <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
                     <option value="1">Once</option>
@@ -610,6 +620,11 @@
                     <option value="3">3 hits</option>
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
+                    <option value="6">6 hits</option>
+                    <option value="7">7 hits</option>
+                    <option value="8">8 hits</option>
+                    <option value="9">9 hits</option>
+                    <option value="10">10 hits</option>
                 </select>
                 <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
                     <option value="1">Once</option>
@@ -644,6 +659,11 @@
                     <option value="3">3 hits</option>
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
+                    <option value="6">6 hits</option>
+                    <option value="7">7 hits</option>
+                    <option value="8">8 hits</option>
+                    <option value="9">9 hits</option>
+                    <option value="10">10 hits</option>
                 </select>
                 <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
                     <option value="1">Once</option>
@@ -1413,6 +1433,11 @@
                     <option value="3">3 hits</option>
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
+                    <option value="6">6 hits</option>
+                    <option value="7">7 hits</option>
+                    <option value="8">8 hits</option>
+                    <option value="9">9 hits</option>
+                    <option value="10">10 hits</option>
                 </select>
                 <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
                     <option value="1">Once</option>
@@ -1447,6 +1472,11 @@
                     <option value="3">3 hits</option>
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
+                    <option value="6">6 hits</option>
+                    <option value="7">7 hits</option>
+                    <option value="8">8 hits</option>
+                    <option value="9">9 hits</option>
+                    <option value="10">10 hits</option>
                 </select>
                 <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
                     <option value="1">Once</option>
@@ -1481,6 +1511,11 @@
                     <option value="3">3 hits</option>
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
+                    <option value="6">6 hits</option>
+                    <option value="7">7 hits</option>
+                    <option value="8">8 hits</option>
+                    <option value="9">9 hits</option>
+                    <option value="10">10 hits</option>
                 </select>
                 <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
                     <option value="1">Once</option>
@@ -1515,6 +1550,11 @@
                     <option value="3">3 hits</option>
                     <option value="4">4 hits</option>
                     <option value="5">5 hits</option>
+                    <option value="6">6 hits</option>
+                    <option value="7">7 hits</option>
+                    <option value="8">8 hits</option>
+                    <option value="9">9 hits</option>
+                    <option value="10">10 hits</option>
                 </select>
                 <select class="stat-drops calc-trigger hide" title="How many times was this move used in a row?">>
                     <option value="1">Once</option>

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -431,6 +431,18 @@ $(".move-selector").change(function () {
 		moveGroupObj.children(".stat-drops").hide();
 		moveGroupObj.children(".move-hits").show();
 		var pokemon = $(this).closest(".poke-info");
+
+		// hide any numbers not in the range
+		moveGroupObj.children(".move-hits").children().prop('disabled', true).hide()
+		var min = move.multihit[0];
+		var max = move.multihit[1];
+		var $moveHits = moveGroupObj.children(".move-hits");
+		// create inclusive range and show hit values in range
+		[...Array(max - min + 1).keys()].forEach(i => {
+			$moveHits.children(`option[value="${i + min}"]`).prop('disabled', false).show();
+		});
+
+		// automatically select 5 if the pokemon's ability is Skill Link
 		var moveHits = (pokemon.find(".ability").val() === 'Skill Link') ? 5 : 3;
 		moveGroupObj.children(".move-hits").val(moveHits);
 	} else if (dropsStats) {


### PR DESCRIPTION
I discovered that the gen 9 move "Population Bomb" is a Muti-hit move, but the damage calculator was only able to display the 10-hit damage result.  Digging deeper I discovered the reason for this was the javascript was only able to handle 2-5 hit moves. I've added a few changes to make move hit more robust (could technically support 3-8 hits in the future) and added a range instead of a static `10` to "Population Bomb"

# Updates
- Change Population bomb to use a range style hits property.
  - `[2, 10]` instead of just `10`
- improve logic for showing number of hits in calc

## Icicle Spear (2-5 hits still works)
<img width="426" alt="Screenshot 2023-04-07 at 3 31 13 PM" src="https://user-images.githubusercontent.com/1904364/230675231-b7f2e30d-3445-43bb-b1f7-0d5db45ab556.png">

## Population Bomb (2-10 hits now supported)
<img width="433" alt="Screenshot 2023-04-07 at 3 30 57 PM" src="https://user-images.githubusercontent.com/1904364/230675237-96a63bea-a686-4126-b43d-1f77e7b602f0.png">
