### PR TITLE
Dark mode restyle

### DIFF
--- a/src/css/dark-theme.css
+++ b/src/css/dark-theme.css
@@ -8,7 +8,7 @@
 
     --button-hover: black;
     --button-selected: #232e51;
-    --fieldset-color: #222;
+    --fieldset-color: #2a2a2a;
 
     --column-1: #2a2a2a;
 }
@@ -49,7 +49,7 @@ fieldset {
 }
 
 select {
-    background-color: var(--background2);
+    background-color: var(--background);
     color: var(--text);
 }
 
@@ -70,12 +70,12 @@ a.links-lighten:visited:hover {
 }
 
 input {
-    background-color: var(--background2);
+    background-color: var(--background);
     color: var(--text);
 }
 
 textarea {
-    background-color: var(--background2);
+    background-color: var(--background);
     color: var(--text);
 }
 

--- a/src/css/dark-theme.css
+++ b/src/css/dark-theme.css
@@ -1,45 +1,54 @@
 /* Dark mode styles */
 
+:root {
+    /* Should make it easier to change colors in the future */
+    --text: #e4e4e4;
+    --background: #1b1b1b;
+    --background2: black;
+
+    --button-hover: black;
+    --button-selected: #232e51;
+    --fieldset-color: #222;
+}
+
 body {
-    color: white;
-    background-color: black;
+    color: var(--text);
+    background-color: var(--background);
 }
 
 .btn {
-    background-color: #161616;
-    color: #B7B7B7;
+    background-color: var(--background);
+    color: var(--text);
 }
 
 .btn:hover {
     z-index: 10;
-    border-color: #888888;
-    background: black;
+    background: var(--button-hover);
 }
 
 .visually-hidden:focus + .btn,
 .btn:hover {
     z-index: 10;
-    border-color: #888888;
-    background: black;
+    background: var(--button-hover);
 }
 
 .visually-hidden:checked + .btn {
     font-weight: bold;
-    color: white;
-    background: #000042;
+    color: var(--text);
+    background: var(--button-selected);
 }
 
 .visually-hidden:disabled + .btn {
-    color: black;
+    color: var(--button-hover);
 }
 
 fieldset {
-    background-color: #222222;
+    background-color: var(--fieldset-color);
 }
 
 select {
-    background-color: black;
-    color: white;
+    background-color: var(--background2);
+    color: var(--text);
 }
 
 a.links-lighten {
@@ -59,60 +68,60 @@ a.links-lighten:visited:hover {
 }
 
 input {
-    background-color: black;
-    color: white;
+    background-color: var(--background2);
+    color: var(--text);
 }
 
 textarea {
-    background-color: black;
-    color: white;
+    background-color: var(--background2);
+    color: var(--text);
 }
 
 .wrapper {
-    background-color: black;
-    color: white;
+    background-color: var(--background);
+    color: var(--text);
 }
 
 a.collapsible-link {
-    color: white;
+    color: var(--text);
 }
 
 .bs-btn {
-    background-color: #161616;
-    color: #B7B7B7;
+    background-color: var(--background);
+    color: var(--text);
 }
 
 .bs-btn:hover {
     z-index: 10;
-    border-color: #888888;
-    background: black;
+    background: var(--button-hover);
+    color: var(--text);
 }
 
 .popover-content {
-    background-color: #161616;
-    color: #B7B7B7;
+    background-color: var(--background);
+    color: var(--text);
 }
 
 .dataTables_info {
-    color: #B7B7B7 !important; /* I know, don't use !important, but w/e */
+    color: var(--text) !important; /* I know, don't use !important, but w/e */
 }
 
 .search-label {
-    color: #B7B7B7;
+    color: var(--text);
 }
 
 tr.odd, tr.even {
-    background-color: rgb(0 0 0) !important;
+    background-color: var(--background) !important;
 }
 
 
 td.sorting_1 {
-    background-color: rgb(25 25 25) !important;
+    background-color: #2a2a2a !important;
 }
 
 
 label:not(.btn) {
-    color: white;
+    color: var(--text);
 }
 
 input.select2-input {

--- a/src/css/dark-theme.css
+++ b/src/css/dark-theme.css
@@ -9,6 +9,8 @@
     --button-hover: black;
     --button-selected: #232e51;
     --fieldset-color: #222;
+
+    --column-1: #2a2a2a;
 }
 
 body {
@@ -111,7 +113,7 @@ tr.odd, tr.even {
 
 
 td.sorting_1 {
-    background-color: #2a2a2a !important;
+    background-color: var(--column-1) !important;
 }
 
 

--- a/src/css/dark-theme.css
+++ b/src/css/dark-theme.css
@@ -4,7 +4,6 @@
     /* Should make it easier to change colors in the future */
     --text: #e4e4e4;
     --background: #1b1b1b;
-    --background2: black;
 
     --button-hover: black;
     --button-selected: #232e51;

--- a/src/css/dark-theme.css
+++ b/src/css/dark-theme.css
@@ -97,11 +97,6 @@ a.collapsible-link {
     color: var(--text);
 }
 
-.popover-content {
-    background-color: var(--background);
-    color: var(--text);
-}
-
 .dataTables_info {
     color: var(--text) !important; /* I know, don't use !important, but w/e */
 }


### PR DESCRIPTION
Changed at request of user Dravos7
https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/post-9578768

Changes:
- Lighten the dark background
- Make text an off-white
- Desaturate the "button selected" blue

Screenshot:
![Screenshot from 2023-04-20 09-42-22](https://user-images.githubusercontent.com/30420527/233398075-7d98fa0c-c631-4395-a255-e7aee460cab0.png)
