### PR TITLE
Restyled Pokemon/move dropdowns for dark mode

### DIFF
--- a/src/css/dark-theme.css
+++ b/src/css/dark-theme.css
@@ -120,6 +120,36 @@ label:not(.btn) {
     color: var(--text);
 }
 
-input.select2-input {
-    color: black;
+/* Select2 Dropdown stylings */
+
+.select2-container .select2-choice {
+    background: var(--background);
+    background-image: linear-gradient(#333, 70%, #1b1b1b);
+    /* Not fully satisfied w/ this gradient, but it's w/e */
+    color: var(--text);
 }
+
+.select2-container .select2-choice .select2-arrow {
+    background: none;
+    border-left: none;
+}
+
+.select2-dropdown-open .select2-choice {
+    -webkit-box-shadow: 0 1px 0 var(--background) inset;
+    box-shadow: 0 1px 0 var(--background) inset;
+}
+
+.select2-drop {
+    background-color: var(--background);
+    color: var(--text);
+}
+
+input.select2-input {
+    color: var(--text);
+    background: url('../js/vendor/select2/select2.png') no-repeat 100% -22px, var(--background);
+    /* 
+    * I have to use this URL because this CSS file is in the dist/css folder,
+    * whereas the Select2 CSS file is right next to the select2.png file
+    */
+}
+

--- a/src/css/dark-theme.css
+++ b/src/css/dark-theme.css
@@ -137,11 +137,17 @@ label:not(.btn) {
 .select2-dropdown-open .select2-choice {
     -webkit-box-shadow: 0 1px 0 var(--background) inset;
     box-shadow: 0 1px 0 var(--background) inset;
+    background-image: none;
 }
 
 .select2-drop {
     background-color: var(--background);
     color: var(--text);
+}
+
+.select2-dropdown-open.select2-drop-above .select2-choice,
+.select2-dropdown-open.select2-drop-above .select2-choices {
+    background-image: none;
 }
 
 input.select2-input {

--- a/src/css/dark-theme.css
+++ b/src/css/dark-theme.css
@@ -152,10 +152,10 @@ label:not(.btn) {
 
 input.select2-input {
     color: var(--text);
-    background: url('../js/vendor/select2/select2.png') no-repeat 100% -22px, var(--background);
     /* 
     * I have to use this URL because this CSS file is in the dist/css folder,
     * whereas the Select2 CSS file is right next to the select2.png file
     */
+    background: url('../js/vendor/select2/select2.png') no-repeat 100% -22px, var(--background);
 }
 


### PR DESCRIPTION
Gives the Select2 dropdowns a dark style when calculator is in dark theme, as opposed to remaining white when rest of elements become dark.

Screenshots:
![Screenshot from 2023-04-25 00-26-30](https://user-images.githubusercontent.com/30420527/234181736-c7c0c1a2-c9f5-4e59-96c2-32096dcc51f8.png)
![Screenshot from 2023-04-25 00-26-39](https://user-images.githubusercontent.com/30420527/234181726-379a037a-4153-4a7a-abbe-c3c1a7eef4e2.png)
![Screenshot from 2023-04-25 00-26-53](https://user-images.githubusercontent.com/30420527/234181720-fe5ddc05-6f67-47fd-babd-3edd2a8e5f01.png)
![Screenshot from 2023-04-25 00-27-01](https://user-images.githubusercontent.com/30420527/234181707-c5d49816-d347-4475-a704-be15b57b4bf7.png)
![Screenshot from 2023-04-25 01-24-42](https://user-images.githubusercontent.com/30420527/234181923-b849a5eb-49b4-4810-8dc7-208e0862196c.png)


