### PR TITLE
Restyled checkboxes and buttons in dark mode

### DIFF
--- a/src/css/dark-theme.css
+++ b/src/css/dark-theme.css
@@ -15,6 +15,7 @@
 body {
     color: var(--text);
     background-color: var(--background);
+    color-scheme: dark;
 }
 
 .btn {


### PR DESCRIPTION
Now darkens buttons and checkboxes when Showdown is in dark mode.

Checkboxes are unchecked:
![Screenshot from 2023-05-16 16-24-14](https://github.com/smogon/damage-calc/assets/30420527/2a0402c0-bc3a-4111-89bb-5647104e4eab)

Checkboxes are checked:
![Screenshot from 2023-05-16 16-24-41](https://github.com/smogon/damage-calc/assets/30420527/101a639b-0907-46e5-8eb6-13d41c6b8509)

In both instances, the unstyled buttons ("Clear Imported Sets", "Export", "Click for  Light Theme") are now visibly darker.

