### PR TITLE
Force word wrap on selected sets

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -421,6 +421,13 @@ table.field {
 .select2-container .select2-choice > .select2-chosen {
     width: 100%;
 }
+
+.select2-chosen {
+	word-wrap: break-word;
+	text-overflow: inherit;
+	white-space: normal !important;
+}
+
 .small-select.select2-container .select2-choice {
     font-size: 0.9em;
     height: 18px;


### PR DESCRIPTION
Fixes problem where selected set names that were too long caused that portion of the calc to be pushed off the page
Before:
![image](https://github.com/smogon/damage-calc/assets/24277518/177e5998-1669-45d9-8b3b-9c737faf0c38)
After:
![image](https://github.com/smogon/damage-calc/assets/24277518/8d6c5900-ad14-451c-b0d5-0073ff03597a)

