### PR TITLE
Gen 4: Fix Klutz not dropping Speed from Iron Ball

### DIFF
--- a/calc/src/mechanics/gen4.ts
+++ b/calc/src/mechanics/gen4.ts
@@ -144,8 +144,9 @@ export function calculateDPP(
 
   let typeEffectiveness = type1Effectiveness * type2Effectiveness;
 
-  // Iron Ball ignores Klutz in generation 4
-  if (typeEffectiveness === 0 && move.hasType('Ground') && defender.hasItem('Iron Ball')) {
+  // Klutz doesn't let Iron Ball ground in generation 4
+  if (typeEffectiveness === 0 && move.hasType('Ground') &&
+    (defender.hasItem('Iron Ball') && defender.ability! !== 'Klutz')) {
     if (type1Effectiveness === 0) {
       type1Effectiveness = 1;
     } else if (defender.types[1] && type2Effectiveness === 0) {

--- a/calc/src/mechanics/util.ts
+++ b/calc/src/mechanics/util.ts
@@ -190,9 +190,11 @@ export function checkForecast(pokemon: Pokemon, weather?: Weather) {
 }
 
 export function checkItem(pokemon: Pokemon, magicRoomActive?: boolean) {
+  // Pokemon with Klutz still get their speed dropped in generation 4
+  if (pokemon.gen.num === 4 && pokemon.item! === 'Iron Ball') return;
   if (
     pokemon.hasAbility('Klutz') && !EV_ITEMS.includes(pokemon.item!) ||
-      magicRoomActive
+    magicRoomActive
   ) {
     pokemon.item = '' as ItemName;
   }


### PR DESCRIPTION
Fixes #560 

Basically, in generation 4, if a Pokemon with the ability Klutz holds an Iron Ball, it should still get its Speed dropped. However, Klutz Pokemon holding an Iron Ball won't be grounded.

![Screenshot from 2023-07-13 00-42-43](https://github.com/smogon/damage-calc/assets/30420527/c440fb2c-9b2f-4b19-9c61-5c6db5e6551e)
