### PR TITLE
Makes entire background dark in dark theme

### DIFF
--- a/src/css/dark-theme.css
+++ b/src/css/dark-theme.css
@@ -12,7 +12,7 @@
     --column-1: #2a2a2a;
 }
 
-body {
+html, body {
     color: var(--text);
     background-color: var(--background);
     color-scheme: dark;


### PR DESCRIPTION
Currently, when looking at the calculator in its dark theme, the bottom of the calculator (beyond the button to switch the theme from light to dark) would just be white. This somewhat defeats the purpose of having a dark theme if there will still be a large patch of white at the bottom of the page (which is much larger on mobile devices). This fixes this.

Before:
![Screenshot from 2023-07-19 10-11-44](https://github.com/smogon/damage-calc/assets/30420527/fea975df-4e04-4bd0-bdbe-2109b4bec44f)


After:
![image](https://github.com/smogon/damage-calc/assets/30420527/157ae3bc-1816-46b2-ba97-e7b4e51b9892)

Screenshots were taken on 1440p monitor and resizing the browser zoom to 80%.