### PR TITLE
Change Revelation Dance's type when attacker has Terastallized

### DIFF
--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -173,7 +173,11 @@ export function calculateSMSSSV(
     desc.terrain = field.terrain;
     desc.moveType = type;
   } else if (move.named('Revelation Dance')) {
-    type = attacker.types[0];
+    if (attacker.teraType) {
+      type = attacker.teraType;
+    } else {
+      type = attacker.types[0];
+    }
   } else if (move.named('Aura Wheel')) {
     if (attacker.named('Morpeko')) {
       type = 'Electric';

--- a/calc/src/test/calc.test.ts
+++ b/calc/src/test/calc.test.ts
@@ -990,6 +990,16 @@ describe('calc', () => {
         testQP('Protosynthesis', {weather: 'Sun'});
         testQPOverride('Quark Drive', {terrain: 'Electric'});
         testQPOverride('Protosynthesis', {weather: 'Sun'});
+        test('Revelation Dance should change type if Pokemon Terastallized', () => {
+          const attacker = Pokemon('Oricorio-Pom-Pom');
+          const defender = Pokemon('Sandaconda');
+          let result = calculate(attacker, defender, Move('Revelation Dance'));
+          expect(result.move.type).toBe('Electric');
+
+          attacker.teraType = 'Water';
+          result = calculate(attacker, defender, Move('Revelation Dance'));
+          expect(result.move.type).toBe('Water');
+        });
       });
     });
   });


### PR DESCRIPTION
Fixes https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/post-9716660

Resulting calc: 0 SpA Tera Water Oricorio-Pom-Pom Revelation Dance vs. 252 HP / 0 SpD Sandaconda: 254-302 (72.9 - 86.7%) -- guaranteed 2HKO after Leftovers recovery

Can create tests if needed