### PR TITLE
Remove Enigma Berry from GSC only list

### DIFF
--- a/calc/src/data/items.ts
+++ b/calc/src/data/items.ts
@@ -83,7 +83,6 @@ const GSC_ONLY = [
   'Pink Bow',
   'Polkadot Bow',
   'PSN Cure Berry',
-  'Enigma Berry',
 ];
 
 const ADV = GSC.filter(i => !GSC_ONLY.includes(i)).concat([


### PR DESCRIPTION
Fixes #472 

Will make sure the Enigma Berry doesn't appear twice in Gens 8 and 9.