### PR TITLE
Remove duplicate spaces in the calc description

### DIFF
--- a/calc/src/desc.ts
+++ b/calc/src/desc.ts
@@ -953,6 +953,7 @@ function buildDescription(description: RawDesc, attacker: Pokemon, defender: Pok
   if (description.isWonderRoom) {
     output += ' in Wonder Room';
   }
+  output = output.replace(/[ ]{2}/g, ' ');
   return output;
 }
 


### PR DESCRIPTION
https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/post-9724268

Before (first line) vs after (second line) with double spaces highlighted.
![image](https://github.com/smogon/damage-calc/assets/30420527/28e91bbd-b65b-4d56-9042-5a876a1a280e)
