### PR TITLE
Improve appearance of click-to-copy confirmation message

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -180,21 +180,33 @@ th {
     font-weight: bold;
     font-size: 1.1em;
     margin: 0.5em 0;
+    position: relative;
 }
 .big-text #mainResult:hover {  /* indicates the presence of click-to-copy function */
     cursor: pointer;
     opacity: 0.7;
 }
 #tooltipText {
+    position: absolute;
+    left: 42%;
+    top: -170%;
     font-size: 0.8em;
     visibility: hidden;
     border-radius: 5px;
-    width: 120px;
-    background-color: black;
+    background-color: rgba(0, 0, 0, 0.7);
     color: white;
     text-align: center;
     padding: 5px;
-    margin-left: 10px;
+    font-weight: normal;
+}
+#tooltipText::after
+{
+    position: absolute;
+    left: 45%;
+    top: 100%;
+    content: '';
+    border: 6px solid transparent;
+    border-top-color: rgba(0, 0, 0, 0.7);
 }
 .small-text {
     font-size: 0.8em;

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -199,8 +199,7 @@ th {
     padding: 5px;
     font-weight: normal;
 }
-#tooltipText::after
-{
+#tooltipText::after {
     position: absolute;
     left: 45%;
     top: 100%;

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -132,9 +132,9 @@
         </div>
     </div>
     <div aria-label="Calculation results" class="main-result-group" role="region">
-        <div class="big-text" title="Click to copy.">
-            <span id="mainResult">Loading...</span>
-            <span id="tooltipText">Copied</span>
+        <div class="big-text">
+            <span id="mainResult" title="Click to copy.">Loading...</span>
+            <div id="tooltipText">Copied</div>
         </div>
         <div class="small-text"><span id="damageValues">(If you see this message for more than a few seconds, try enabling JavaScript.)</span>
         </div>

--- a/src/js/index_randoms_controls.js
+++ b/src/js/index_randoms_controls.js
@@ -205,6 +205,6 @@ $("#mainResult").click(function () {
 		document.getElementById('tooltipText').style.visibility = 'visible';
 		setTimeout(function () {
 			document.getElementById('tooltipText').style.visibility = 'hidden';
-		}, 2000);
+		}, 1500);
 	});
 });

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -1473,6 +1473,6 @@ $("#mainResult").click(function () {
 		document.getElementById('tooltipText').style.visibility = 'visible';
 		setTimeout(function () {
 			document.getElementById('tooltipText').style.visibility = 'hidden';
-		}, 2000);
+		}, 1500);
 	});
 });

--- a/src/randoms.template.html
+++ b/src/randoms.template.html
@@ -132,9 +132,9 @@
         </div>
     </div>
     <div aria-label="Calculation results" class="main-result-group" role="region">
-        <div class="big-text" title="Click to copy.">
-            <span id="mainResult">Loading...</span>
-            <span id="tooltipText">Copied</span>
+        <div class="big-text">
+            <span id="mainResult" title="Click to copy.">Loading...</span>
+            <div id="tooltipText">Copied</div>
         </div>
         <div class="small-text"><span id="damageValues">(If you see this message for more than a few seconds, try enabling JavaScript.)</span>
         </div>


### PR DESCRIPTION
Since originally authoring the pull request that implemented this feature (https://github.com/smogon/damage-calc/pull/441), I have noticed a few ways it could be better.

**Firstly**, there is an issue when the damage calculation message has a certain length, such that the hidden element that appears on click is pushed to a second line, while no text is there. This results in the abnormality shown in the screenshots below: 

![Picture1](https://github.com/smogon/damage-calc/assets/48886784/053c5c67-8e0c-4510-b14e-e6819aee9166)

![Picture2](https://github.com/smogon/damage-calc/assets/48886784/0e72a477-4c8c-44f7-9f98-1caaef31f2a7)

The layout is pushed down by a blank line that accommodates the hidden element.

In order to fix it, I have changed the position of the confirmation message to appear above the text. I have set its position to absolute, so it will not interfere with the rest of the layout.

Below are three screenshots of how it looks, including two extreme cases of a very short output message, and a very long individual move output. Please let me know if there are any other cases I should consider for the position of the message.

![Picture3](https://github.com/smogon/damage-calc/assets/48886784/f89b3e95-2900-49dd-8e56-7bbe921613a4)

![Picture4](https://github.com/smogon/damage-calc/assets/48886784/0fc0e59e-5da1-4efe-b5b5-39fbeb2abb0b)

![Picture5](https://github.com/smogon/damage-calc/assets/48886784/ed787402-5ccd-43d8-b6e7-05f20c189bc5)

**Secondly**, I reduced the duration of the appearance from 2s to 1.5s, because I found it lingered for too long.

Thanks.
