### PR TITLE
Fix "No matches found" in dark mode

### DIFF
--- a/src/css/dark-theme.css
+++ b/src/css/dark-theme.css
@@ -151,6 +151,10 @@ label:not(.btn) {
     background-image: none;
 }
 
+.select2-no-results {
+    background-color: var(--background) !important;
+}
+
 input.select2-input {
     color: var(--text);
     /* 
@@ -159,4 +163,3 @@ input.select2-input {
     */
     background: url('../js/vendor/select2/select2.png') no-repeat 100% -22px, var(--background);
 }
-


### PR DESCRIPTION
Currently, when you search through the dropdown, when you search for something that has no matches, it should display that there are "No matches found." However, in dark mode, the text is changed to a light color, but the background still displays as a dark background, meaning that you see white text on a white background. This fixes this issue.

Screenshot:
![image](https://github.com/smogon/damage-calc/assets/30420527/8ec87890-dfcc-4dec-b617-3e7e23b21569)
![image](https://github.com/smogon/damage-calc/assets/30420527/1b10a703-57e3-4431-898a-f346148ba9d2)
