### PR TITLE
Gens 4-9: Remove interaction between Natural Gift and Berry Juice

### DIFF
--- a/calc/src/mechanics/gen4.ts
+++ b/calc/src/mechanics/gen4.ts
@@ -88,7 +88,8 @@ export function calculateDPP(
     desc.moveBP = basePower;
   } else if (move.named('Judgment') && attacker.item && attacker.item.includes('Plate')) {
     move.type = getItemBoostType(attacker.item)!;
-  } else if (move.named('Natural Gift') && attacker.item && attacker.item.includes('Berry')) {
+  } else if (move.named('Natural Gift') && attacker.item && attacker.item.includes('Berry') &&
+      attacker.item !== 'Berry Juice') {
     const gift = getNaturalGift(gen, attacker.item)!;
     move.type = gift.t;
     move.bp = gift.p;

--- a/calc/src/mechanics/gen56.ts
+++ b/calc/src/mechanics/gen56.ts
@@ -108,7 +108,8 @@ export function calculateBWXY(
     move.type = getItemBoostType(attacker.item)!;
   } else if (move.named('Techno Blast') && attacker.item && attacker.item.includes('Drive')) {
     move.type = getTechnoBlast(attacker.item)!;
-  } else if (move.named('Natural Gift') && attacker.item && attacker.item.includes('Berry')) {
+  } else if (move.named('Natural Gift') && attacker.item && attacker.item.includes('Berry') &&
+      attacker.item !== 'Berry Juice') {
     const gift = getNaturalGift(gen, attacker.item)!;
     move.type = gift.t;
     move.bp = gift.p;

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -162,7 +162,8 @@ export function calculateSMSSSV(
     type = getTechnoBlast(attacker.item)!;
   } else if (move.named('Multi-Attack') && attacker.item && attacker.item.includes('Memory')) {
     type = getMultiAttack(attacker.item)!;
-  } else if (move.named('Natural Gift') && attacker.item && attacker.item.includes('Berry')) {
+  } else if (move.named('Natural Gift') && attacker.item && attacker.item.includes('Berry') &&
+      attacker.item !== 'Berry Juice') {
     const gift = getNaturalGift(gen, attacker.item)!;
     type = gift.t;
     desc.moveType = type;
@@ -826,7 +827,7 @@ export function calculateBasePowerSMSSSV(
     desc.moveBP = basePower;
     break;
   case 'Natural Gift':
-    if (attacker.item?.includes('Berry')) {
+    if (attacker.item?.includes('Berry') && !attacker.item?.includes('Juice')) {
       const gift = getNaturalGift(gen, attacker.item)!;
       basePower = gift.p;
       desc.attackerItem = attacker.item;


### PR DESCRIPTION
Currently, when a Pokemon uses Natural Gift while holding a Berry Juice, it is treated as a 1 BP Normal-type move. This will now accurately display that a Pokemon using Natural Gift while holding a Berry Juice will deal 0 damage.

![Screenshot from 2023-12-26 15-57-44](https://github.com/smogon/damage-calc/assets/30420527/385ea514-56d2-489b-8714-ad0a9b7d6978)
