### PR TITLE
Implement IV display in calcs when applicable

### DIFF
--- a/calc/src/mechanics/gen3.ts
+++ b/calc/src/mechanics/gen3.ts
@@ -121,7 +121,7 @@ export function calculateADV(
     return result;
   }
 
-  desc.HPEVs = `${defender.evs.hp} HP`;
+  desc.HPEVs = getEVDescriptionText(gen, defender, 'hp');
 
   const fixedDamage = handleFixedDamageMoves(attacker, move);
   if (fixedDamage) {

--- a/calc/src/mechanics/gen4.ts
+++ b/calc/src/mechanics/gen4.ts
@@ -161,7 +161,7 @@ export function calculateDPP(
     return result;
   }
 
-  desc.HPEVs = `${defender.evs.hp} HP`;
+  desc.HPEVs = getEVDescriptionText(gen, defender, 'hp');
 
   const fixedDamage = handleFixedDamageMoves(attacker, move);
   if (fixedDamage) {

--- a/calc/src/mechanics/gen56.ts
+++ b/calc/src/mechanics/gen56.ts
@@ -237,7 +237,7 @@ export function calculateBWXY(
     return result;
   }
 
-  desc.HPEVs = `${defender.evs.hp} HP`;
+  desc.HPEVs = getEVDescriptionText(gen, defender, 'hp');
 
   const fixedDamage = handleFixedDamageMoves(attacker, move);
   if (fixedDamage) {

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -403,7 +403,7 @@ export function calculateSMSSSV(
     return result;
   }
 
-  desc.HPEVs = `${defender.evs.hp} HP`;
+  desc.HPEVs = getEVDescriptionText(gen, defender, 'hp');
 
   const fixedDamage = handleFixedDamageMoves(attacker, move);
   if (fixedDamage) {

--- a/calc/src/mechanics/util.ts
+++ b/calc/src/mechanics/util.ts
@@ -606,6 +606,8 @@ export function countBoosts(gen: Generation, boosts: StatsTable) {
   return sum;
 }
 
+const formatIV = (iv?: number) => iv !== undefined && iv !== 31 ? ` ${iv} IVs` : '';
+
 export function getEVDescriptionText(
   gen: Generation,
   pokemon: Pokemon,
@@ -618,7 +620,7 @@ export function getEVDescriptionText(
     : nature.plus === stat ? '+'
     : nature.minus === stat ? '-'
     : '') + ' ' +
-     Stats.displayStat(stat));
+     Stats.displayStat(stat)) + formatIV(pokemon.ivs[stat]);
 }
 
 export function handleFixedDamageMoves(attacker: Pokemon, move: Move) {

--- a/calc/src/mechanics/util.ts
+++ b/calc/src/mechanics/util.ts
@@ -611,12 +611,12 @@ const formatIV = (iv?: number) => iv !== undefined && iv !== 31 ? ` ${iv} IVs` :
 export function getEVDescriptionText(
   gen: Generation,
   pokemon: Pokemon,
-  stat: 'atk' | 'def' | 'spd' | 'spa',
-  natureName: NatureName
+  stat: 'atk' | 'def' | 'spd' | 'spa' | 'hp',
+  natureName?: NatureName
 ): string {
   const nature = gen.natures.get(toID(natureName))!;
   return (pokemon.evs[stat] +
-    (nature.plus === nature.minus ? ''
+    (stat === 'hp' || nature.plus === nature.minus ? ''
     : nature.plus === stat ? '+'
     : nature.minus === stat ? '-'
     : '') + ' ' +

--- a/calc/src/test/calc.test.ts
+++ b/calc/src/test/calc.test.ts
@@ -218,9 +218,9 @@ describe('calc', () => {
               Pokemon('Mew', ivs[1]),
               Move('Explosion'),
             ).rawDesc;
-            const ivDesc = [result.attackEVs, result.defenseEVs]
-              .map((value, ..._) => value?.match(RegExp('\\d+ IVs')));
-            expect(ivDesc[i]).toHaveLength(1);
+            const ivDesc = [result.attackEVs, result.HPEVs + '/' + result.defenseEVs]
+              .map((value, ..._) => value?.match(RegExp('\\d+ IVs', 'g')));
+            expect(ivDesc[i]).toHaveLength(i + 1);
             expect(ivDesc[+!i]).toBeNull();
           }
         });

--- a/calc/src/test/calc.test.ts
+++ b/calc/src/test/calc.test.ts
@@ -208,6 +208,25 @@ describe('calc', () => {
       });
     });
 
+    describe('IVs are shown if applicable', () => {
+      inGens(3, 9, ({gen, calculate, Pokemon, Move}) => {
+        test(`Gen ${gen}`, () => {
+          const ivs = [{ivs: {atk: 9, def: 9, hp: 9}, evs: {atk: 9, def: 9, hp: 9}}, {}];
+          for (let i = 0; i < 2; i++, ivs.reverse()) {
+            const result = calculate(
+              Pokemon('Mew', ivs[0]),
+              Pokemon('Mew', ivs[1]),
+              Move('Explosion'),
+            ).rawDesc;
+            const ivDesc = [result.attackEVs, result.defenseEVs]
+              .map((value, ..._) => value?.match(RegExp('\\d+ IVs')));
+            expect(ivDesc[i]).toHaveLength(1);
+            expect(ivDesc[+!i]).toBeNull();
+          }
+        });
+      });
+    });
+
     inGens(4, 9, ({gen, calculate, Pokemon, Move}) => {
       const zapdos = Pokemon('Zapdos', {item: 'Iron Ball'});
       if (gen === 4) {


### PR DESCRIPTION
Given the set ```
Abomasnow @ Icy Rock
Level: 100
Modest Nature
Tera Type: Ground
Ability: Snow Warning
EVs: 168 HP / 252 SpA / 88 Spe
IVs: 30 HP / 29 Atk / 28 Def / 27 SpA / 26 SpD / 25 Spe
- Blizzard
- Earth Power
- Leaf Storm
- Aurora Veil``` using Blizzard against itself, the calc returns ```
252+ SpA Abomasnow Blizzard vs. 168 HP / 0 SpD Abomasnow: 180-213 (49.7 - 58.8%) -- 99.6% chance to 2HKO
``` New behavior:
```
252+ SpA 27 IVs Abomasnow Blizzard vs. 168 HP / 0 SpD Abomasnow: 180-213 (49.7 - 58.8%) -- 99.6% chance to 2HKO```

Let me know if the test structure is acceptable, I'm aware I have a divergent view on how testing is written ;) 