### PR TITLE
Improve Stellar handling

### DIFF
--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -106,7 +106,11 @@ export function calculateSMSSSV(
   };
 
   // only display tera type if it applies
-  if (attacker.teraType !== 'Stellar' || move.isStellarFirstUse) {
+  if (attacker.teraType === 'Stellar' && move.name === 'Tera Blast') {
+    // tera blast has special behavior with tera stellar
+    desc.attackerTera = attacker.teraType + (move.isStellarFirstUse ? ' (First Use)' : '');
+    move.dropsStats = 1;
+  } else if (attacker.teraType !== 'Stellar' || move.isStellarFirstUse) {
     desc.attackerTera = attacker.teraType;
   }
   if (defender.teraType !== 'Stellar') desc.defenderTera = defender.teraType;
@@ -887,8 +891,6 @@ export function calculateBasePowerSMSSSV(
     desc.moveBP = basePower;
     break;
   case 'Tera Blast':
-    desc.attackerTera = attacker.teraType; // always show
-    if (move.isStellarFirstUse) desc.attackerTera += ' (First Use)';
     basePower = attacker.teraType === 'Stellar' ? 100 : 80;
     desc.moveBP = basePower;
     break;

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -99,13 +99,17 @@ export function calculateSMSSSV(
 
   const desc: RawDesc = {
     attackerName: attacker.name,
-    attackerTera: attacker.teraType,
     moveName: move.name,
     defenderName: defender.name,
-    defenderTera: defender.teraType,
     isDefenderDynamaxed: defender.isDynamaxed,
     isWonderRoom: field.isWonderRoom,
   };
+
+  // only display tera type if it applies
+  if (attacker.teraType !== 'Stellar' || move.isStellarFirstUse) {
+    desc.attackerTera = attacker.teraType;
+  }
+  if (defender.teraType !== 'Stellar') desc.defenderTera = defender.teraType;
 
   const result = new Result(gen, attacker, defender, move, field, 0, desc);
 
@@ -882,6 +886,8 @@ export function calculateBasePowerSMSSSV(
     desc.moveBP = basePower;
     break;
   case 'Tera Blast':
+    desc.attackerTera = attacker.teraType; // always show
+    if (move.isStellarFirstUse) desc.attackerTera += ' (First Use)';
     basePower = attacker.teraType === 'Stellar' ? 100 : 80;
     desc.moveBP = basePower;
     break;

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -364,6 +364,7 @@ export function calculateSMSSSV(
   }
 
   if (move.type === 'Stellar') {
+    desc.defenderTera = defender.teraType; // always show in this case
     typeEffectiveness = !defender.teraType ? 1 : 2;
   }
 

--- a/calc/src/test/calc.test.ts
+++ b/calc/src/test/calc.test.ts
@@ -1209,6 +1209,38 @@ describe('calc', () => {
           "0 Atk Weavile with an ally's Flower Gift Power Spot boosted switching boosted Pursuit (80 BP) vs. 0 HP / 0 Def Vulpix in Sun: 399-469 (183.8 - 216.1%) -- guaranteed OHKO"
         );
       });
+      describe('Tera Stellar', () => {
+        const terastal = Pokemon('Arceus', {teraType: 'Stellar'});
+        const control = Pokemon('Arceus');
+        test('should only be displayed on defender for Stellar attacks', () => {
+          expect(calculate(control, terastal, Move('Tera Blast'))
+            .rawDesc
+            .defenderTera).toBeUndefined();
+          expect(calculate(terastal, terastal, Move('Tera Blast'))
+            .rawDesc
+            .defenderTera).toBeDefined();
+          // make sure that it isn't caring about stellar first use
+          expect(calculate(terastal, terastal, Move('Tera Blast', {isStellarFirstUse: true}))
+            .rawDesc
+            .defenderTera).toBeDefined();
+          expect(calculate(control, terastal, Move('Tera Blast', {isStellarFirstUse: true}))
+            .rawDesc
+            .defenderTera).toBeUndefined();
+        });
+        test('should not be displayed for non-boosted attacks', () => expect(
+          calculate(terastal, control, Move('Judgment', {isStellarFirstUse: false}))
+            .rawDesc
+            .attackerTera
+        ).toBeUndefined());
+        test('should distinguish between first use for Tera Blast', () => {
+          // I don't exactly care what the difference is
+          const result = [true, false].map((isStellarFirstUse, ..._) =>
+            calculate(terastal, control, Move('Tera Blast', {isStellarFirstUse}))
+              .rawDesc
+              .attackerTera);
+          expect(result[0]).not.toEqual(result[1]);
+        });
+      });
     });
     describe('Descriptions', () => {
       inGen(9, ({gen, calculate, Pokemon, Move}) => {


### PR DESCRIPTION
Currently, Tera Stellar is shown in too many cases. When it's active, it is always shown, but this is misleading:

* When using a move other than tera blast, it only applies on the first time, otherwise it's identical to not being there at all
* It does nothing defensively, outside of giving a weakness to Stellar type attacks

Even in the case of Tera Blast, the first use has a different stab modifier, but both cases just display 'Tera Stellar' and 100 BP, which is incorrect --- the same description should ideally always yield the same numbers.
