### PR TITLE
Seeds now treated as no item in their respective terrains

### DIFF
--- a/calc/src/mechanics/util.ts
+++ b/calc/src/mechanics/util.ts
@@ -294,6 +294,7 @@ export function checkSeedBoost(pokemon: Pokemon, field: Field) {
           : Math.min(6, pokemon.boosts.spd + 1);
       }
     }
+    pokemon.item = '' as ItemName;
   }
 }
 


### PR DESCRIPTION
When a Pokemon holding a terrain seed is in its respective terrain, it will now be treated as having no item after it gains the boost, which removes Knock Off's boost and makes Poltergeist useless.

Case: Life Orb Absol using Knock Off/Poltergeist on Grassy Seed Rillaboom in gen 8

Current:
`252 Atk Life Orb Absol Knock Off (97.5 BP) vs. +1 240 HP / 0 Def Grassy Seed Rillaboom: 152-179 (37.9 - 44.6%) -- guaranteed 3HKO after Grassy Terrain recovery`
`252 Atk Life Orb Absol Poltergeist vs. +1 240 HP / 0 Def Grassy Seed Rillaboom: 114-135 (28.4 - 33.6%) -- 95.9% chance to 4HKO after Grassy Terrain recovery`

New:
`252 Atk Life Orb Absol Knock Off vs. +1 240 HP / 0 Def Rillaboom: 101-121 (25.1 - 30.1%) -- 0.1% chance to 4HKO after Grassy Terrain recovery`
`Absol Poltergeist vs. Rillaboom: 0-0 (0 - 0%) -- possibly the worst move ever`