### PR TITLE
Pokemon with Wind Rider should gain an Attack boost if in Tailwind

### DIFF
--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -46,6 +46,7 @@ import {
   isQPActive,
   getStabMod,
   getStellarStabMod,
+  checkWindRider
 } from './util';
 
 export function calculateSMSSSV(
@@ -82,6 +83,9 @@ export function calculateSMSSSV(
   checkDownload(defender, attacker, field.isWonderRoom);
   checkIntrepidSword(attacker, gen);
   checkIntrepidSword(defender, gen);
+
+  checkWindRider(attacker, field.attackerSide)
+  checkWindRider(defender, field.defenderSide)
 
   if (move.named('Meteor Beam', 'Electro Shot')) {
     attacker.boosts.spa +=

--- a/calc/src/mechanics/util.ts
+++ b/calc/src/mechanics/util.ts
@@ -253,6 +253,12 @@ export function checkDauntlessShield(source: Pokemon, gen: Generation) {
   }
 }
 
+export function checkWindRider(source: Pokemon, attackingSide: Side) {
+  if (source.hasAbility('Wind Rider') && attackingSide.isTailwind) {
+    source.boosts.atk = Math.min(6, source.boosts.atk + 1);
+  }
+}
+
 export function checkEmbody(source: Pokemon, gen: Generation) {
   if (gen.num < 9) return;
   switch (source.ability) {


### PR DESCRIPTION
When a Pokemon has the ability Wind Rider and has Tailwind on its side of the field, it will gain an Attack boost.

Case: Brambleghast using Power Whip against Brambleghast, with the attacking Brambleghast under Tailwind.

Current:
`0 Atk Brambleghast Power Whip vs. 0 HP / 0 Def Brambleghast: 97-115 (38.6 - 45.8%) -- guaranteed 3HKO`

New:
`+1 0 Atk Brambleghast Power Whip vs. 0 HP / 0 Def Brambleghast: 146-172 (58.1 - 68.5%) -- guaranteed 2HKO`