### PR TITLE
Accuracy-dependent multihit moves should not get BP boost from Tera

### DIFF
--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -926,7 +926,7 @@ export function calculateBasePowerSMSSSV(
   basePower = OF16(Math.max(1, pokeRound((basePower * chainMods(bpMods, 41, 2097152)) / 4096)));
   if (
     attacker.teraType && move.type === attacker.teraType &&
-    attacker.hasType(attacker.teraType) && move.hits === 1 &&
+    attacker.hasType(attacker.teraType) && move.hits === 1 && !move.multiaccuracy &&
     move.priority <= 0 && move.bp > 0 && !move.named('Dragon Energy', 'Eruption', 'Water Spout') &&
     basePower < 60 && gen.num >= 9
   ) {

--- a/calc/src/move.ts
+++ b/calc/src/move.ts
@@ -42,6 +42,7 @@ export class Move implements State.Move {
   breaksProtect: boolean;
   isZ: boolean;
   isMax: boolean;
+  multiaccuracy: boolean;
 
   constructor(
     gen: I.Generation,
@@ -157,6 +158,7 @@ export class Move implements State.Move {
     this.breaksProtect = !!data.breaksProtect;
     this.isZ = !!data.isZ;
     this.isMax = !!data.isMax;
+    this.multiaccuracy = !!data.multiaccuracy;
 
     if (!this.bp) {
       // Assume max happiness for these moves because the calc doesn't support happiness


### PR DESCRIPTION
Multi-hit moves that can hit once because of their accuracy (currently Population Bomb, Triple Axel, and Triple Kick) currently get the Base Power boost from same Tera type; however all multi-hit moves do not get the boost.