### PR TITLE
Gen 789: Tablets and Vessel of Ruin be active even when attacker ignores the ability

### DIFF
--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -136,7 +136,9 @@ export function calculateSMSSSV(
     'Full Metal Body',
     'Neutralizing Gas',
     'Prism Armor',
-    'Shadow Shield'
+    'Shadow Shield',
+    'Tablets of Ruin',
+    'Vessel of Ruin'
   );
 
   const attackerIgnoresAbility = attacker.hasAbility('Mold Breaker', 'Teravolt', 'Turboblaze');


### PR DESCRIPTION
https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/post-10051402