### PR TITLE
Attackers with the Punching Glove should have moves not make contact

### DIFF
--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -1153,6 +1153,7 @@ export function calculateBPModsSMSSSV(
   if (attacker.hasItem('Punching Glove') && move.flags.punch) {
     bpMods.push(4506);
     desc.attackerItem = attacker.item;
+    move.flags.contact = 0;
   }
 
   if (gen.num <= 8 && defender.hasAbility('Heatproof') && move.hasType('Fire')) {


### PR DESCRIPTION
https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/post-10061460

If we compare the results with a Melmetal using Double Iron Bash on a Fluffy Bewear with and without the Punching Glove item:

Before:
`0 Atk Iron Fist Melmetal Double Iron Bash (2 hits) vs. 0 HP / 0 Def Fluffy Bewear: 126-150 (33 - 39.3%) -- approx. 99.9% chance to 3HKO`
`0 Atk Punching Glove Iron Fist Melmetal Double Iron Bash (2 hits) vs. 0 HP / 0 Def Fluffy Bewear: 140-166 (36.7 - 43.5%) -- approx. 3HKO`

140 / 126 = 1.111 ~ 1.1
166 / 150 = 1.107 ~ 1.1

After:
`0 Atk Iron Fist Melmetal Double Iron Bash (2 hits) vs. 0 HP / 0 Def Fluffy Bewear: 126-150 (33 - 39.3%) -- approx. 99.9% chance to 3HKO`
`0 Atk Punching Glove Iron Fist Melmetal Double Iron Bash (2 hits) vs. 0 HP / 0 Def Bewear: 282-332 (74 - 87.1%) -- approx. 2HKO`

282 / 126 = 2.238 ~ 2.2
332 / 150 = 2.213 ~ 2.2

2.2 = 1.1 / 0.5 (the debuff associated with Fluffy)