### PR TITLE
Neutralizing Gas will actually remove defender's ability

### DIFF
--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -134,7 +134,6 @@ export function calculateSMSSSV(
 
   const defenderIgnoresAbility = defender.hasAbility(
     'Full Metal Body',
-    'Neutralizing Gas',
     'Prism Armor',
     'Shadow Shield',
     'Tablets of Ruin',
@@ -161,6 +160,36 @@ export function calculateSMSSSV(
     } else {
       defender.ability = '' as AbilityName;
     }
+  }
+
+  // The following abilities ignore Neutralizing Gas, so they are an exception
+  const ignoresNeutralizingGas = [
+    'As One (Glastrier)',
+    'As One (Spectrier)',
+    'Battle Bond',
+    'Comatose',
+    'Disguise',
+    'Gulp Missile',
+    'Ice Face',
+    'Multitype',
+    'Neutralizing Gas',
+    'Power Construct',
+    'RKS System',
+    'Schooling',
+    'Shields Down',
+    'Stance Change',
+    'Tera Shift',
+    'Zen Mode',
+    'Zero to Hero'
+  ]
+
+  if (attacker.hasAbility('Neutralizing Gas') && !defender.hasAbility(...ignoresNeutralizingGas)) {
+    desc.attackerAbility = attacker.ability;
+    defender.ability = '' as AbilityName;
+  }
+  if (defender.hasAbility('Neutralizing Gas') && !attacker.hasAbility(...ignoresNeutralizingGas)) {
+    desc.defenderAbility = defender.ability;
+    attacker.ability = '' as AbilityName;
   }
 
   // Merciless does not ignore Shell Armor, damage dealt to a poisoned Pokemon with Shell Armor


### PR DESCRIPTION
https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/post-10029886

Neutralizing Gas will completely remove the opposing Pokemon's ability, with the exception of certain abilities, the list of which was taken from the [Smogon Dex](https://www.smogon.com/dex/sv/abilities/neutralizing-gas/).