### PR TITLE
Hadron Engine affects ungrounded Pokemon

### DIFF
--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -1394,7 +1394,7 @@ export function calculateAtModsSMSSSV(
     (attacker.hasAbility('Hadron Engine') && move.category === 'Special' &&
       field.hasTerrain('Electric')) ||
     (attacker.hasAbility('Orichalcum Pulse') && move.category === 'Physical' &&
-      field.hasWeather('Sun', 'Harsh Sunshine'))
+      field.hasWeather('Sun', 'Harsh Sunshine') && !attacker.hasItem('Utility Umbrella'))
   ) {
     atMods.push(5461);
     desc.attackerAbility = attacker.ability;

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -1392,9 +1392,9 @@ export function calculateAtModsSMSSSV(
 
   if (
     (attacker.hasAbility('Hadron Engine') && move.category === 'Special' &&
-      field.hasTerrain('Electric') && isGrounded(attacker, field)) ||
+      field.hasTerrain('Electric')) ||
     (attacker.hasAbility('Orichalcum Pulse') && move.category === 'Physical' &&
-      field.hasWeather('Sun', 'Harsh Sunshine') && !attacker.hasItem('Utility Umbrella'))
+      field.hasWeather('Sun', 'Harsh Sunshine'))
   ) {
     atMods.push(5461);
     desc.attackerAbility = attacker.ability;


### PR DESCRIPTION
https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/post-9940077

Hadron Engine should give its boost to Pokemon that aren't grounded ([proof](https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-9427717)).