### PR TITLE
Fix Gen 2 Random Battle calc for role system

### DIFF
--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -598,7 +598,7 @@ $(".set-selector").change(function () {
 			$(this).closest('.poke-info').find(".extraSetAbilities").text(listAbilities.join(', '));
 			if (gen >= 2) $(this).closest('.poke-info').find(".item-pool").show();
 			$(this).closest('.poke-info').find(".extraSetItems").text(listItems.join(', '));
-			if (gen >= 9 || gen === 7 || gen === 6 || gen === 5 || gen === 4 || gen === 3) {
+			if (gen >= 9 || gen === 7 || gen === 6 || gen === 5 || gen === 4 || gen === 3 || gen === 2) {
 				$(this).closest('.poke-info').find(".role-pool").show();
 				if (gen >= 9) $(this).closest('.poke-info').find(".tera-type-pool").show();
 			}
@@ -652,7 +652,7 @@ $(".set-selector").change(function () {
 			}
 			var setMoves = set.moves;
 			if (randset) {
-				if (gen < 9 && gen !== 7 && gen !== 6 && gen !== 5 && gen !== 4 && gen !== 3) {
+				if (gen < 9 && gen !== 7 && gen !== 6 && gen !== 5 && gen !== 4 && gen !== 3 && gen !== 2) {
 					setMoves = randset.moves;
 				} else {
 					setMoves = [];
@@ -969,7 +969,7 @@ function createPokemon(pokeInfo) {
 			evs[stat] = (set.evs && typeof set.evs[legacyStat] !== "undefined") ? set.evs[legacyStat] : 0;
 		}
 		var moveNames = set.moves;
-		if (isRandoms && (gen >= 9 || gen === 7 || gen === 6 || gen === 5 || gen === 4 || gen === 3)) {
+		if (isRandoms && (gen >= 9 || gen === 7 || gen === 6 || gen === 5 || gen === 4 || gen === 3 || gen === 2)) {
 			moveNames = [];
 			for (var role in set.roles) {
 				for (var q = 0; q < set.roles[role].moves.length; q++) {

--- a/src/randoms.template.html
+++ b/src/randoms.template.html
@@ -500,7 +500,7 @@
                         <div>Tera Type Pool</div>
                         <small class="extraSetTeraTypes"></small>
                     </div>
-                    <div class="role-pool gen-specific g3 g4 g5 g6 g7 g9">
+                    <div class="role-pool gen-specific g2 g3 g4 g5 g6 g7 g9">
                         <div>Role Pool</div>
                         <small class="extraSetRoles"></small>
                     </div>
@@ -1370,7 +1370,7 @@
                         <div>Tera Type Pool</div>
                         <small class="extraSetTeraTypes"></small>
                     </div>
-                    <div class="role-pool gen-specific g3 g4 g5 g6 g7 g9">
+                    <div class="role-pool gen-specific g2 g3 g4 g5 g6 g7 g9">
                         <div>Role Pool</div>
                         <small class="extraSetRoles"></small>
                     </div>


### PR DESCRIPTION
Hello, like other gens (9/7/6/5/4/3 so far) gen 2 random battles has moved to the "role-system", which makes pkmn.cc's data different, thus changing the way it should be read.

This PR should fix it, it's essentially the same as the previous two: https://github.com/smogon/damage-calc/commit/3852b986b48df29ba234c015632a6eec1882cdcb and https://github.com/smogon/damage-calc/commit/a9e0f4686c26c8a33398508be9e912e83396c746.

Thanks in advance!