### PR TITLE
Honkalculate no longer covers tiers

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -221,10 +221,7 @@ th {
     text-align: center;
     width: 27.5em;
 }
-.holder-0 {
-    /* position: absolute;
-    top: 151px; */
-}
+
 #holder-2 tr {
     white-space: nowrap;
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -222,8 +222,8 @@ th {
     width: 27.5em;
 }
 .holder-0 {
-    position: absolute;
-    top: 151px;
+    /* position: absolute;
+    top: 151px; */
 }
 #holder-2 tr {
     white-space: nowrap;
@@ -523,4 +523,8 @@ table.field {
 .extraSetItems,
 .extraSetMoves {
     width: 100%;
+}
+
+.flex-parent {
+	display: flex;
 }

--- a/src/honkalculate.template.html
+++ b/src/honkalculate.template.html
@@ -887,7 +887,7 @@
         </fieldset>
     </div>
     <div>
-        <fieldset class="panel holder-0">
+        <fieldset class="panel" id="holder-0">
             <legend class="panel-heading panel-title">Damage Results</legend>
             <table class="hide display" id="holder-2">
                 <thead>

--- a/src/honkalculate.template.html
+++ b/src/honkalculate.template.html
@@ -96,7 +96,8 @@
 
 </div>
 
-    <div class="panel-group" id="accordion">
+	<div class="flex-parent">
+		<div class="panel-group" id="accordion">
         <fieldset class="panel panel-default poke-info" id="p1">
             <legend class="panel-heading panel-title">
                 <a data-toggle="collapse" data-parent="#accordion" href="#collapseOne" class="collapsible-link">>  Pokemon</a>
@@ -905,6 +906,9 @@
             </table>
         </fieldset>
     </div>
+	</div>
+
+
     <script type="text/javascript">
         var linkExtension = '.template.html';
     </script>

--- a/src/js/honkalculate_controls.js
+++ b/src/js/honkalculate_controls.js
@@ -342,10 +342,10 @@ function calcDTDimensions() {
 	});
 
 	var theadBottomOffset = getBottomOffset($(".sorting"));
-	var heightUnderDT = getBottomOffset($(".holder-0")) - getBottomOffset($("#holder-2 tbody"));
+	var heightUnderDT = getBottomOffset($("#holder-0")) - getBottomOffset($("#holder-2 tbody"));
 	dtHeight = $(document).height() - theadBottomOffset - heightUnderDT;
 	dtWidth = $(window).width() - $("#holder-2").offset().left;
-	dtWidth -= 2 * parseFloat($(".holder-0").css("padding-right"));
+	dtWidth -= 2 * parseFloat($("#holder-0").css("padding-right"));
 }
 
 function getBottomOffset(obj) {


### PR DESCRIPTION
https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/post-10085323

The Honkalculate table no longer uses `position: absolute` to position itself on the page, so it (shouldn't) cover the list of tiers that you are pulling sets from.

As an aside (outside the scope of this PR), the Honkalculator is kinda jank and I also dislike how the UI looks and behaves.