### PR TITLE
Helping Hand + Multi-Hit move fix

### DIFF
--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -631,6 +631,11 @@ export function calculateSMSSSV(
     const origDefBoost = desc.defenseBoost;
     const origAtkBoost = desc.attackBoost;
 
+    // Helping Hand only applies to the first hit of a multi-hit move
+    if (!(move.dropsStats && move.timesUsed! > 1)) {
+      field.attackerSide.isHelpingHand = false;
+    }
+
     let numAttacks = 1;
     if (move.dropsStats && move.timesUsed! > 1) {
       desc.moveTurns = `over ${move.timesUsed} turns`;

--- a/calc/src/test/calc.test.ts
+++ b/calc/src/test/calc.test.ts
@@ -564,6 +564,21 @@ describe('calc', () => {
         );
       });
     });
+
+    inGens(7, 9, ({gen, calculate, Pokemon, Move, Field}) => {
+      test(`Multi-hit interaction with Helping Hand (gen ${gen})`, () => {
+        const result = calculate(
+          Pokemon('Mamoswine'),
+          Pokemon('Hippowdon'),
+          Move('Icicle Spear'),
+          Field({attackerSide: {isHelpingHand: true}}),
+        );
+        expect(result.range()).toEqual([206, 248]);
+        expect(result.desc()).toBe(
+          '0 Atk Mamoswine Helping Hand Icicle Spear (3 hits) vs. 0 HP / 0 Def Hippowdon: 206-248 (57.7 - 69.4%) -- approx. 2HKO'
+        );
+      });
+    });
   });
 
 


### PR DESCRIPTION
Helping Hand should only apply a boost to the first hit of a multi-hit move. I've only seen this tested in gen 9, but it's possible that this change could apply to previous gens as well.

Without HH:
      0 Atk Mamoswine Icicle Spear (3 hits) vs. 0 HP / 0 Def Hippowdon: 180-216 (50.4 - 60.5%) -- approx. 2HKO

Current with HH (boost across all 3 hits): 
      0 Atk Mamoswine Helping Hand Icicle Spear (3 hits) vs. 0 HP / 0 Def Hippowdon: 258-312 (72.2 - 87.3%) -- approx. 2HKO

 New with HH (only the first hit is boosted):
      0 Atk Mamoswine Helping Hand Icicle Spear (3 hits) vs. 0 HP / 0 Def Hippowdon: 206-248 (57.7 - 69.4%) -- approx. 2HKO