### PR TITLE
FOIT will only occur when the calc loads the first time

### DIFF
--- a/src/js/dark-theme-toggle.js
+++ b/src/js/dark-theme-toggle.js
@@ -13,7 +13,10 @@
 * It will be truey and incorrectly cause the
 * dark theme to load.
 */
-var prefersDarkTheme = localStorage.getItem('darkTheme') ? localStorage.getItem('darkTheme') === 'true' : window.matchMedia('(prefers-color-scheme: dark)').matches;
+if (!localStorage.getItem('darkTheme')) {
+	localStorage.setItem('darkTheme', window.matchMedia('(prefers-color-scheme: dark)').matches);
+}
+var prefersDarkTheme = localStorage.getItem('darkTheme') === 'true';
 var darkThemeButton = document.getElementById('dark-theme-toggle');
 darkThemeButton.innerText = prefersDarkTheme ? 'Click for Light Theme' : 'Click for Dark Theme';
 if (prefersDarkTheme) {


### PR DESCRIPTION
https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/post-10082377

Essentially, this will immediately set the "darkTheme" setting when the calc loads the first time so that it will not undergo FOIT after the first load after clearing localStorage. Before, to prevent this behavior, the user would have to manually set the theme to light mode and then to dark mode with the button on the bottom; now they no longer need to do this.

I do not know how to remove the damage calculator from inducing FOIT for the initial load, but from what I am [reading online](https://css-tricks.com/a-complete-guide-to-dark-mode-on-the-web/#aa-using-localstorage), it seems to be inevitable because JavaScript gets loaded after the CSS.