### PR TITLE
Collision Course and Electro Drift get their boosts against Stellar-types

### DIFF
--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -1045,7 +1045,7 @@ export function calculateBPModsSMSSSV(
       field.defenderSide.isForesight;
     const isRingTarget =
       defender.hasItem('Ring Target') && !defender.hasAbility('Klutz');
-    const types = defender.teraType ? [defender.teraType] : defender.types;
+    const types = defender.teraType && defender.teraType !== 'Stellar' ? [defender.teraType] : defender.types;
     const type1Effectiveness = getMoveEffectiveness(
       gen,
       move,


### PR DESCRIPTION
https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/post-10133853

If a Pokemon weak to Collision Course or Electro Drift Terastallizes into a Stellar-type, it will still get the 1.333x boost to the damage dealt ([proof](https://www.smogon.com/forums/threads/scarlet-violet-battle-mechanics-research.3709545/post-10133856))

Before:
No Tera:
252 Atk Orichalcum Pulse Koraidon Collision Course (133.3251953125 BP) vs. 0 HP / 0 Def Regigigas: 548-648 (151.8 - 179.5%) -- guaranteed OHKO
With Tera Stellar:
252 Atk Orichalcum Pulse Koraidon Collision Course vs. 0 HP / 0 Def Regigigas: 414-488 (114.6 - 135.1%) -- guaranteed OHKO

After:
No Tera:
252 Atk Orichalcum Pulse Koraidon Collision Course (133.3251953125 BP) vs. 0 HP / 0 Def Regigigas: 548-648 (151.8 - 179.5%) -- guaranteed OHKO
With Tera Stellar
252 Atk Orichalcum Pulse Koraidon Collision Course (133.3251953125 BP) vs. 0 HP / 0 Def Regigigas: 548-648 (151.8 - 179.5%) -- guaranteed OHKO