### PR TITLE
feat: allow to Import showdown from GET parameters

### DIFF
--- a/src/js/index_randoms_controls.js
+++ b/src/js/index_randoms_controls.js
@@ -199,6 +199,17 @@ $(document).ready(function () {
 			}
 		}
 	}
+
+	let importParam = params.get('import');
+	if (importParam) {
+        try {
+            var decodedImport = atob(importParam); // Decode base64
+            $('.import-team-text').val(decodedImport); // Set value to text area
+        } catch (e) {
+            console.error('Failed to decode Import parameter:', e);
+        }
+	}
+	
 	$(".calc-trigger").bind("change keyup", PC_HANDLER);
 	performCalculations();
 });


### PR DESCRIPTION
### PR Description: Import showdown directly from the URL 

#### Overview
Recently I started writing a web-based version of a save editing app ([PKHeX Web](https://pkhex-web.github.io)). This change allows importing Pokemon data directly from PKHeX Web (or any other app) using a base64-encoded URL parameter named `import`

#### Changes Made

    - Decodes a base64-encoded string from the `import` URL parameter.
    - Sets the decoded string as the value of the text area for importing Pokemon data.

#### Purpose
Facilitates seamless integration between any external app and the Pokemon calculator. Allows users to transfer Pokemon data (party or box) from PKHeX Web to the calculator, streamlining their workflow.