### PR TITLE
Flower Gift should stack with Huge Power

### DIFF
--- a/calc/src/mechanics/gen4.ts
+++ b/calc/src/mechanics/gen4.ts
@@ -502,10 +502,6 @@ export function calculateAttackDPP(
     attack = Math.floor(attack * 1.5);
     desc.attackerAbility = attacker.ability;
     desc.weather = field.weather;
-  } else if (field.attackerSide.isFlowerGift && field.hasWeather('Sun') && isPhysical) {
-    attack = Math.floor(attack * 1.5);
-    desc.weather = field.weather;
-    desc.isFlowerGiftAttacker = true;
   } else if (
     (isPhysical &&
       (attacker.hasAbility('Hustle') || (attacker.hasAbility('Guts') && attacker.status)) ||
@@ -516,6 +512,13 @@ export function calculateAttackDPP(
   } else if (isPhysical && attacker.hasAbility('Slow Start') && attacker.abilityOn) {
     attack = Math.floor(attack / 2);
     desc.attackerAbility = attacker.ability;
+  }
+
+  if (field.attackerSide.isFlowerGift && !attacker.hasAbility('Flower Gift') &&
+    field.hasWeather('Sun') && isPhysical) {
+    attack = Math.floor(attack * 1.5);
+    desc.weather = field.weather;
+    desc.isFlowerGiftAttacker = true;
   }
 
   if ((isPhysical ? attacker.hasItem('Choice Band') : attacker.hasItem('Choice Specs')) ||

--- a/calc/src/mechanics/gen56.ts
+++ b/calc/src/mechanics/gen56.ts
@@ -850,13 +850,6 @@ export function calculateAtModsBWXY(
     desc.attackerAbility = attacker.ability;
     desc.weather = field.weather;
   } else if (
-    field.attackerSide.isFlowerGift &&
-    field.hasWeather('Sun', 'Harsh Sunshine') &&
-    move.category === 'Physical') {
-    atMods.push(6144);
-    desc.weather = field.weather;
-    desc.isFlowerGiftAttacker = true;
-  } else if (
     (attacker.hasAbility('Defeatist') && attacker.curHP() <= attacker.maxHP() / 2) ||
     (attacker.hasAbility('Slow Start') && attacker.abilityOn && move.category === 'Physical')
   ) {
@@ -865,6 +858,16 @@ export function calculateAtModsBWXY(
   } else if (attacker.hasAbility('Huge Power', 'Pure Power') && move.category === 'Physical') {
     atMods.push(8192);
     desc.attackerAbility = attacker.ability;
+  }
+
+  if (
+    field.attackerSide.isFlowerGift &&
+    !attacker.hasAbility('Flower Gift') &&
+    field.hasWeather('Sun', 'Harsh Sunshine') &&
+    move.category === 'Physical') {
+    atMods.push(6144);
+    desc.weather = field.weather;
+    desc.isFlowerGiftAttacker = true;
   }
 
   if ((attacker.hasItem('Thick Club') &&

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -1327,13 +1327,6 @@ export function calculateAtModsSMSSSV(
     atMods.push(6144);
     desc.attackerAbility = attacker.ability;
   } else if (
-    field.attackerSide.isFlowerGift &&
-    field.hasWeather('Sun', 'Harsh Sunshine') &&
-    move.category === 'Physical') {
-    atMods.push(6144);
-    desc.weather = field.weather;
-    desc.isFlowerGiftAttacker = true;
-  } else if (
     (attacker.hasAbility('Guts') && attacker.status && move.category === 'Physical') ||
     (attacker.curHP() <= attacker.maxHP() / 3 &&
       ((attacker.hasAbility('Overgrow') && move.hasType('Grass')) ||
@@ -1366,6 +1359,16 @@ export function calculateAtModsSMSSSV(
   ) {
     atMods.push(8192);
     desc.attackerAbility = attacker.ability;
+  }
+
+  if (
+    field.attackerSide.isFlowerGift &&
+    !attacker.hasAbility('Flower Gift') &&
+    field.hasWeather('Sun', 'Harsh Sunshine') &&
+    move.category === 'Physical') {
+    atMods.push(6144);
+    desc.weather = field.weather;
+    desc.isFlowerGiftAttacker = true;
   }
 
   if ((defender.hasAbility('Thick Fat') && move.hasType('Fire', 'Ice')) ||


### PR DESCRIPTION
Fixes https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/post-10148870

Before:
252+ Atk Choice Band Huge Power Azumarill Return vs. 252 HP / 0 Def Abomasnow: 257-303 (66.9 - 78.9%) -- guaranteed 2HKO after Leftovers recovery (without Flower Gift)
252+ Atk Choice Band Huge Power Azumarill Return vs. 252 HP / 0 Def Abomasnow: 257-303 (66.9 - 78.9%) -- guaranteed 2HKO after Leftovers recovery (with Flower Gift and sun active)

After:
252+ Atk Choice Band Huge Power Azumarill Return vs. 252 HP / 0 Def Abomasnow: 257-303 (66.9 - 78.9%) -- guaranteed 2HKO after Leftovers recovery (without Flower Gift)
252+ Atk Choice Band Huge Power Azumarill with an ally's Flower Gift Return vs. 252 HP / 0 Def Abomasnow in Sun: 385-453 (100.2 - 117.9%) -- guaranteed OHKO (with Flower Gift and sun active)