### PR TITLE
Brighten the buttons in dark mode

### DIFF
--- a/src/css/dark-theme.css
+++ b/src/css/dark-theme.css
@@ -5,7 +5,8 @@
     --text: #e4e4e4;
     --background: #1b1b1b;
 
-    --button-hover: black;
+    --button-color: #353535;
+    --button-hover: var(--background);
     --button-selected: #232e51;
     --fieldset-color: #2a2a2a;
 
@@ -19,7 +20,7 @@ html, body {
 }
 
 .btn {
-    background-color: var(--background);
+    background-color: var(--button-color);
     color: var(--text);
 }
 


### PR DESCRIPTION
Currently, the buttons share their color with the background color, which makes it less visually distinct compared to them. Brightening the buttons will make it so that they are more noticeable.

Contrast ratio is 9.64:1; checked using [WebAIM's contrast checker](https://webaim.org/resources/contrastchecker/?fcolor=E4E4E4&bcolor=353535)