### PR TITLE
Random Battles: Add support for Doubles and Baby

### DIFF
--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -27,6 +27,11 @@ if (!Array.prototype.indexOf) {
 	};
 }
 
+// Constants for referring to the various Random Battles formats
+var RANDOMS = "Randoms";
+var DOUBLES_RANDOMS = "Doubles Randoms";
+var BABY_RANDOMS = "Baby Randoms";
+
 function startsWith(string, target) {
 	return (string || '').slice(0, target.length) === target;
 }
@@ -621,12 +626,22 @@ $(".set-selector").change(function () {
 		var moveObj;
 		var abilityObj = pokeObj.find(".ability");
 		var itemObj = pokeObj.find(".item");
-		var randset = $("#randoms").prop("checked") ? randdex[pokemonName] : undefined;
+		var randset = undefined;
+		if ($("#randoms").prop("checked")) {
+			if (gen === 9) {
+				// The Gen 9 randdex contains information for multiple Random Battles formats for each Pokemon.
+				// Duraludon, for example, has data for Randoms, Doubles Randoms, and Baby Randoms.
+				// Therefore, the information for only the format chosen should be used.
+				randset = randdex[pokemonName][setName];
+			} else {
+				randset = randdex[pokemonName];
+			}
+		}
 		var regSets = pokemonName in setdex && setName in setdex[pokemonName];
 
 		if (randset) {
-			var listItems = randdex[pokemonName].items ? randdex[pokemonName].items : [];
-			var listAbilities = randdex[pokemonName].abilities ? randdex[pokemonName].abilities : [];
+			var listItems = randset.items ? randset.items : [];
+			var listAbilities = randset.abilities ? randset.abilities : [];
 			if (gen >= 3) $(this).closest('.poke-info').find(".ability-pool").show();
 			$(this).closest('.poke-info').find(".extraSetAbilities").text(listAbilities.join(', '));
 			if (gen >= 2) $(this).closest('.poke-info').find(".item-pool").show();
@@ -635,12 +650,12 @@ $(".set-selector").change(function () {
 				$(this).closest('.poke-info').find(".role-pool").show();
 				if (gen >= 9) $(this).closest('.poke-info').find(".tera-type-pool").show();
 			}
-			var listRoles = randdex[pokemonName].roles ? Object.keys(randdex[pokemonName].roles) : [];
+			var listRoles = randset.roles ? Object.keys(randset.roles) : [];
 			$(this).closest('.poke-info').find(".extraSetRoles").text(listRoles.join(', '));
 			var listTeraTypes = [];
-			if (randdex[pokemonName].roles && gen >= 9) {
-				for (var roleName in randdex[pokemonName].roles) {
-					var role = randdex[pokemonName].roles[roleName];
+			if (randset.roles && gen >= 9) {
+				for (var roleName in randset.roles) {
+					var role = randset.roles[roleName];
 					for (var q = 0; q < role.teraTypes.length; q++) {
 						if (listTeraTypes.indexOf(role.teraTypes[q]) === -1) {
 							listTeraTypes.push(role.teraTypes[q]);
@@ -912,7 +927,8 @@ $(".forme").change(function () {
 		$(this).parent().siblings().find(".teraToggle").prop("checked", true);
 	}
 	var isRandoms = $("#randoms").prop("checked");
-	var pokemonSets = isRandoms ? randdex[pokemonName] : setdex[pokemonName];
+	var pokemonSets = isRandoms ? gen === 9 ? randdex[pokemonName][setName] :
+		randdex[pokemonName] : setdex[pokemonName];
 	var chosenSet = pokemonSets && pokemonSets[setName];
 	var greninjaSet = $(this).val().indexOf("Greninja") !== -1;
 	var isAltForme = $(this).val() !== pokemonName;
@@ -1268,6 +1284,51 @@ var SETDEX = [
 	typeof SETDEX_SS === 'undefined' ? {} : SETDEX_SS,
 	typeof SETDEX_SV === 'undefined' ? {} : SETDEX_SV,
 ];
+
+// Creates a single dictionary for all Gen 9 Random Battles formats
+var COMBINED_GEN9 = typeof GEN9RANDOMBATTLE === 'undefined' ? {} : GEN9RANDOMBATTLE;
+
+// Regular Random Battles
+for (var i = 0; i < Object.keys(COMBINED_GEN9).length; i++) {
+	var pokemon = Object.keys(COMBINED_GEN9)[i];
+	var sets = COMBINED_GEN9[pokemon];
+	COMBINED_GEN9[pokemon] = {RANDOMS: sets};
+}
+
+// Random Double Battles
+var GEN9RANDOMDOUBLESBATTLE = typeof GEN9RANDOMDOUBLESBATTLE === 'undefined' ? {} : GEN9RANDOMDOUBLESBATTLE;
+for (var i = 0; i < Object.keys(GEN9RANDOMDOUBLESBATTLE).length; i++) {
+	var pokemon = Object.keys(GEN9RANDOMDOUBLESBATTLE)[i];
+	var sets = GEN9RANDOMDOUBLESBATTLE[pokemon];
+	if (!(pokemon in COMBINED_GEN9)) {
+		COMBINED_GEN9[pokemon] = {};
+	}
+	COMBINED_GEN9[pokemon][DOUBLES_RANDOMS] = sets;
+}
+
+// Baby Random Battles
+var GEN9BABYRANDOMBATTLE = typeof GEN9BABYRANDOMBATTLE === 'undefined' ? {} : GEN9BABYRANDOMBATTLE;
+for (var i = 0; i < Object.keys(GEN9BABYRANDOMBATTLE).length; i++) {
+	var pokemon = Object.keys(GEN9BABYRANDOMBATTLE)[i];
+	var sets = GEN9BABYRANDOMBATTLE[pokemon];
+	if (!(pokemon in COMBINED_GEN9)) {
+		COMBINED_GEN9[pokemon] = {};
+	}
+	COMBINED_GEN9[pokemon][BABY_RANDOMS] = sets;
+}
+
+// COMBINED_GEN9 will now be a dictionary that will have the hierarchy Pokemon -> Format -> Sets
+// An example using Duraludon would be:
+// {
+//		...
+//		Duraludon: {
+//			Randoms: {...},
+//			Doubles Randoms: {...},
+//			Baby Randoms: {...}
+//		}
+//		...
+// }
+
 var RANDDEX = [
 	{},
 	typeof GEN1RANDOMBATTLE === 'undefined' ? {} : GEN1RANDOMBATTLE,
@@ -1278,7 +1339,7 @@ var RANDDEX = [
 	typeof GEN6RANDOMBATTLE === 'undefined' ? {} : GEN6RANDOMBATTLE,
 	typeof GEN7RANDOMBATTLE === 'undefined' ? {} : GEN7RANDOMBATTLE,
 	typeof GEN8RANDOMBATTLE === 'undefined' ? {} : GEN8RANDOMBATTLE,
-	typeof GEN9RANDOMBATTLE === 'undefined' ? {} : GEN9RANDOMBATTLE,
+	COMBINED_GEN9,
 ];
 var gen, genWasChanged, notation, pokedex, setdex, randdex, typeChart, moves, abilities, items, calcHP, calcStat, GENERATION;
 
@@ -1407,12 +1468,28 @@ function getSetOptions(sets) {
 		});
 		if ($("#randoms").prop("checked")) {
 			if (pokeName in randdex) {
-				setOptions.push({
-					pokemon: pokeName,
-					set: 'Randoms Set',
-					text: pokeName + " (Randoms)",
-					id: pokeName + " (Randoms)"
-				});
+				if (gen === 9) {
+					// The Gen 9 randdex contains information for multiple Random Battles formats for each Pokemon.
+					// Duraludon, for example, has data for Randoms, Doubles Randoms, and Baby Randoms.
+					// Therefore, all of this information has to be populated within the set options.
+					var randTypes = Object.keys(randdex[pokeName]);
+					for (var j = 0; j < randTypes.length; j++) {
+						var rand = randTypes[j];
+						setOptions.push({
+							pokemon: pokeName + (rand === RANDOMS ? "" : " (" + rand.split(' ')[0] + ")"),
+							set: rand + ' Set',
+							text: pokeName + " (" + rand + ")",
+							id: pokeName + " (" + rand + ")"
+						});
+					}
+				} else {
+					setOptions.push({
+						pokemon: pokeName,
+						set: 'Randoms Set',
+						text: pokeName + " (Randoms)",
+						id: pokeName + " (Randoms)"
+					});
+				}
 			}
 		} else {
 			if (pokeName in setdex) {

--- a/src/randoms.template.html
+++ b/src/randoms.template.html
@@ -1592,6 +1592,8 @@
     <script type="text/javascript" src="./calc/stats.js?"></script>
     <script type="text/javascript" src="./calc/data/species.js?"></script>
     <script type="text/javascript" src="https://data.pkmn.cc/randbats/js/gen9randombattle.js?"></script>
+    <script type="text/javascript" src="https://data.pkmn.cc/randbats/js/gen9randomdoublesbattle.js?"></script>
+    <script type="text/javascript" src="https://data.pkmn.cc/randbats/js/gen9babyrandombattle.js?"></script>
     <script type="text/javascript" src="https://data.pkmn.cc/randbats/js/gen8randombattle.js?"></script>
     <script type="text/javascript" src="https://data.pkmn.cc/randbats/js/gen7randombattle.js?"></script>
     <script type="text/javascript" src="https://data.pkmn.cc/randbats/js/gen6randombattle.js?"></script>


### PR DESCRIPTION
Adds calculator support for Random Double Battles and Baby Random Battles for gen 9, as was suggested by grape tylenol in the Discord server

Code is somewhat hardcoded for gen 9 only, so if we can figure out how to improve it to support other formats (such as Gen 8 Random Double Battles, Gen 8 BDSP Random Battles, or other future Random Battles formats) without having to hardcode it then it would be ideal.

<details>
  <summary>Screenshots</summary>

Pokemon Selection:
![image](https://github.com/user-attachments/assets/18521b07-19d4-40b2-bac4-8ebe68cdf6ab)

Random Doubles Sets:
![image](https://github.com/user-attachments/assets/9d83aac5-ddc7-48bc-b7c0-23c5c7b21a45)

Baby Random Sets:
![image](https://github.com/user-attachments/assets/78f8cbaf-5040-4d56-b0e3-1256236360ec)

</details>