### PR TITLE
Gen 8 Random Battles: Add support for Doubles and BDSP

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -41,6 +41,8 @@
         "GEN6RANDOMBATTLE": false,
         "GEN7RANDOMBATTLE": false,
         "GEN8RANDOMBATTLE": false,
+        "GEN8BDSPRANDOMBATTLE": false,
+        "GEN8RANDOMDOUBLESBATTLE": false,
         "GEN9RANDOMBATTLE": false,
         "GEN9RANDOMDOUBLESBATTLE": false,
         "GEN9BABYRANDOMBATTLE": false,

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -623,8 +623,8 @@ $(".set-selector").change(function () {
 		var itemObj = pokeObj.find(".item");
 		var randset;
 		if ($("#randoms").prop("checked")) {
-			if (gen === 9) {
-				// The Gen 9 randdex contains information for multiple Random Battles formats for each Pokemon.
+			if (gen >= 8) {
+				// The Gens 8 and 9 randdex contains information for multiple Random Battles formats for each Pokemon.
 				// Duraludon, for example, has data for Randoms, Doubles Randoms, and Baby Randoms.
 				// Therefore, the information for only the format chosen should be used.
 				randset = randdex[pokemonName][setName];
@@ -922,7 +922,7 @@ $(".forme").change(function () {
 		$(this).parent().siblings().find(".teraToggle").prop("checked", true);
 	}
 	var isRandoms = $("#randoms").prop("checked");
-	var pokemonSets = isRandoms ? gen === 9 ? randdex[pokemonName][setName] :
+	var pokemonSets = isRandoms ? gen >= 8 ? randdex[pokemonName][setName] :
 		randdex[pokemonName] : setdex[pokemonName];
 	var chosenSet = pokemonSets && pokemonSets[setName];
 	var greninjaSet = $(this).val().indexOf("Greninja") !== -1;
@@ -1280,6 +1280,36 @@ var SETDEX = [
 	typeof SETDEX_SV === 'undefined' ? {} : SETDEX_SV,
 ];
 
+// Creates a single dictionary for all Gen 8 Random Battles formats
+var GEN8 = {
+	"Randoms": typeof GEN8RANDOMBATTLE === 'undefined' ? {} : GEN8RANDOMBATTLE,
+	"Doubles Randoms": typeof GEN8RANDOMDOUBLESBATTLE === 'undefined' ? {} : GEN8RANDOMDOUBLESBATTLE,
+	"BDSP Randoms": typeof GEN8BDSPRANDOMBATTLE === 'undefined' ? {} : GEN8BDSPRANDOMBATTLE,
+};
+
+// COMBINED_GEN8 will be a dictionary that will have the hierarchy Pokemon -> Format -> Sets
+// An example using Absol would be:
+// {
+//		...
+//		Absol: {
+//			Randoms: {...},
+//			Doubles Randoms: {...},
+//			BDSP Randoms: {...}
+//		}
+//		...
+// }
+var COMBINED_GEN8 = {};
+for (var format in GEN8) {
+	var formatSets = GEN8[format];
+	for (var pokemon in formatSets) {
+		var sets = formatSets[pokemon];
+		if (!(pokemon in COMBINED_GEN8)) {
+			COMBINED_GEN8[pokemon] = {};
+		}
+		COMBINED_GEN8[pokemon][format] = sets;
+	}
+}
+
 // Creates a single dictionary for all Gen 9 Random Battles formats
 var GEN9 = {
 	"Randoms": typeof GEN9RANDOMBATTLE === 'undefined' ? {} : GEN9RANDOMBATTLE,
@@ -1322,7 +1352,7 @@ var RANDDEX = [
 	typeof GEN5RANDOMBATTLE === 'undefined' ? {} : GEN5RANDOMBATTLE,
 	typeof GEN6RANDOMBATTLE === 'undefined' ? {} : GEN6RANDOMBATTLE,
 	typeof GEN7RANDOMBATTLE === 'undefined' ? {} : GEN7RANDOMBATTLE,
-	typeof GEN8RANDOMBATTLE === 'undefined' ? {} : GEN8RANDOMBATTLE,
+	COMBINED_GEN8,
 	COMBINED_GEN9,
 ];
 var gen, genWasChanged, notation, pokedex, setdex, randdex, typeChart, moves, abilities, items, calcHP, calcStat, GENERATION;
@@ -1453,8 +1483,8 @@ function getSetOptions(sets) {
 		});
 		if ($("#randoms").prop("checked")) {
 			if (pokeName in randdex) {
-				if (gen === 9) {
-					// The Gen 9 randdex contains information for multiple Random Battles formats for each Pokemon.
+				if (gen >= 8) {
+					// The Gen 8 and 9 randdex contains information for multiple Random Battles formats for each Pokemon.
 					// Duraludon, for example, has data for Randoms, Doubles Randoms, and Baby Randoms.
 					// Therefore, all of this information has to be populated within the set options.
 					var randTypes = Object.keys(randdex[pokeName]);

--- a/src/randoms.template.html
+++ b/src/randoms.template.html
@@ -1595,6 +1595,8 @@
     <script type="text/javascript" src="https://data.pkmn.cc/randbats/js/gen9randomdoublesbattle.js?"></script>
     <script type="text/javascript" src="https://data.pkmn.cc/randbats/js/gen9babyrandombattle.js?"></script>
     <script type="text/javascript" src="https://data.pkmn.cc/randbats/js/gen8randombattle.js?"></script>
+    <script type="text/javascript" src="https://data.pkmn.cc/randbats/js/gen8randomdoublesbattle.js?"></script>
+    <script type="text/javascript" src="https://data.pkmn.cc/randbats/js/gen8bdsprandombattle.js?"></script>
     <script type="text/javascript" src="https://data.pkmn.cc/randbats/js/gen7randombattle.js?"></script>
     <script type="text/javascript" src="https://data.pkmn.cc/randbats/js/gen6randombattle.js?"></script>
     <script type="text/javascript" src="https://data.pkmn.cc/randbats/js/gen5randombattle.js?"></script>


### PR DESCRIPTION
Uses similar code to #632 but for Gen 8 instead of Gen 9