### PR TITLE
Terapagos-S's Tera Starstorm will hit Ghost-types

### DIFF
--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -281,6 +281,11 @@ export function calculateSMSSSV(
     } else if (attacker.name.includes('Ogerpon-Wellspring')) {
       type = 'Water';
     }
+  } else if (
+    move.named('Tera Starstorm') && attacker.name === 'Terapagos-Stellar'
+  ) {
+    move.target = 'allAdjacentFoes';
+    type = 'Stellar';
   }
 
   let hasAteAbilityTypeChange = false;
@@ -1030,11 +1035,6 @@ export function calculateBPModsSMSSSV(
     move.target = 'allAdjacentFoes';
     bpMods.push(6144);
     desc.moveBP = basePower * 1.5;
-  } else if (
-    move.named('Tera Starstorm') && attacker.name === 'Terapagos-Stellar'
-  ) {
-    move.target = 'allAdjacentFoes';
-    move.type = 'Stellar';
   } else if ((move.named('Knock Off') && !resistedKnockOffDamage) ||
     (move.named('Misty Explosion') && isGrounded(attacker, field) && field.hasTerrain('Misty')) ||
     (move.named('Grav Apple') && field.isGravity)


### PR DESCRIPTION
https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/page-39#post-10206123

Before:
Terapagos-Terastal Tera Starstorm vs. Gengar: 0-0 (0 - 0%) -- possibly the worst move ever
Terapagos-Stellar Tera Starstorm vs. Gengar: 0-0 (0 - 0%) -- possibly the worst move ever

After:
Terapagos-Terastal Tera Starstorm vs. Gengar: 0-0 (0 - 0%) -- possibly the worst move ever
252 SpA Choice Specs Terapagos-Stellar Tera Starstorm vs. 0 HP / 4 SpD Gengar: 223-263 (85.4 - 100.7%) -- 6.3% chance to OHKO

Also this code block never really should've been in the `calculateBPModsSMSSSV` function because it doesn't really touch `bpMods` and should have instead been placed with other moves that change their type in `calculateSMSSSV`.