### PR TITLE
Change type imports to explicit TS syntax

### DIFF
--- a/calc/.eslintrc
+++ b/calc/.eslintrc
@@ -6,6 +6,7 @@
     "@typescript-eslint/no-unused-vars": "off",
     "jest/no-standalone-expect": "off",
     "@typescript-eslint/restrict-template-expressions": "off",
-    "jest/no-conditional-expect": "off"
+    "jest/no-conditional-expect": "off",
+    "@typescript-eslint/consistent-type-imports": "error"
   }
 }

--- a/calc/src/calc.ts
+++ b/calc/src/calc.ts
@@ -1,8 +1,8 @@
 import {Field} from './field';
-import {Generation} from './data/interface';
-import {Move} from './move';
-import {Pokemon} from './pokemon';
-import {Result} from './result';
+import type {Generation} from './data/interface';
+import type {Move} from './move';
+import type {Pokemon} from './pokemon';
+import type {Result} from './result';
 
 import {calculateRBYGSC} from './mechanics/gen12';
 import {calculateADV} from './mechanics/gen3';

--- a/calc/src/data/abilities.ts
+++ b/calc/src/data/abilities.ts
@@ -1,4 +1,4 @@
-import * as I from './interface';
+import type * as I from './interface';
 import {toID} from '../util';
 
 const RBY: string[] = [];

--- a/calc/src/data/index.ts
+++ b/calc/src/data/index.ts
@@ -1,4 +1,4 @@
-import * as I from './interface';
+import type * as I from './interface';
 
 import {Abilities} from './abilities';
 import {Items} from './items';

--- a/calc/src/data/items.ts
+++ b/calc/src/data/items.ts
@@ -1,4 +1,4 @@
-import * as I from './interface';
+import type * as I from './interface';
 import {toID} from '../util';
 
 const RBY: string[] = [];

--- a/calc/src/data/moves.ts
+++ b/calc/src/data/moves.ts
@@ -1,5 +1,5 @@
-import * as I from '../data/interface';
-import {toID, DeepPartial, assignWithout, extend} from '../util';
+import type * as I from '../data/interface';
+import {type DeepPartial, toID, assignWithout, extend} from '../util';
 
 export interface MoveData {
   readonly name?: string;

--- a/calc/src/data/natures.ts
+++ b/calc/src/data/natures.ts
@@ -1,4 +1,4 @@
-import * as I from './interface';
+import type * as I from './interface';
 import {toID} from '../util';
 
 export const NATURES: {[name: string]: [I.StatID, I.StatID]} = {

--- a/calc/src/data/species.ts
+++ b/calc/src/data/species.ts
@@ -1,5 +1,5 @@
-﻿import * as I from './interface';
-import {toID, extend, DeepPartial, assignWithout} from '../util';
+import type * as I from './interface';
+import {type DeepPartial, toID, extend, assignWithout} from '../util';
 
 export interface SpeciesData {
   readonly types: [I.TypeName] | [I.TypeName, I.TypeName];

--- a/calc/src/data/types.ts
+++ b/calc/src/data/types.ts
@@ -1,4 +1,4 @@
-import * as I from './interface';
+import type * as I from './interface';
 import {toID, extend} from '../util';
 
 export type TypeChart = {

--- a/calc/src/desc.ts
+++ b/calc/src/desc.ts
@@ -1,8 +1,8 @@
-import {Generation, Weather, Terrain, TypeName, ID} from './data/interface';
-import {Field, Side} from './field';
-import {Move} from './move';
-import {Pokemon} from './pokemon';
-import {Damage, damageRange} from './result';
+import type {Generation, Weather, Terrain, TypeName, ID} from './data/interface';
+import type {Field, Side} from './field';
+import type {Move} from './move';
+import type {Pokemon} from './pokemon';
+import {type Damage, damageRange} from './result';
 import {error} from './util';
 // NOTE: This needs to come last to simplify bundling
 import {isGrounded} from './mechanics/util';

--- a/calc/src/field.ts
+++ b/calc/src/field.ts
@@ -1,5 +1,5 @@
-import {State} from './state';
-import {GameType, Weather, Terrain} from './data/interface';
+import type {State} from './state';
+import type {GameType, Weather, Terrain} from './data/interface';
 
 export class Field implements State.Field {
   gameType: GameType;

--- a/calc/src/index.ts
+++ b/calc/src/index.ts
@@ -44,8 +44,8 @@
 // that the correct loading order being followed.
 
 import {Generations} from './data';
-import {State} from './state';
-import * as I from './data/interface';
+import type {State} from './state';
+import type * as I from './data/interface';
 import * as A from './adaptable';
 
 // The loading strategy outlined in the comment above breaks in the browser when we start reusing
@@ -142,10 +142,10 @@ export function calcStat(
 
 export {Field, Side} from './field';
 export {Result} from './result';
-export {GenerationNum, StatsTable, StatID} from './data/interface';
+export {type GenerationNum, type StatsTable, type StatID} from './data/interface';
 export {Generations} from './data/index';
 export {toID} from './util';
-export {State} from './state';
+export {type State} from './state';
 
 export {ABILITIES} from './data/abilities';
 export {ITEMS, MEGA_STONES} from './data/items';

--- a/calc/src/items.ts
+++ b/calc/src/items.ts
@@ -1,4 +1,4 @@
-import {Generation, TypeName, StatID} from './data/interface';
+import type {Generation, TypeName, StatID} from './data/interface';
 import {toID} from './util';
 
 export const SEED_BOOSTED_STAT: {[item: string]: StatID} = {

--- a/calc/src/mechanics/gen12.ts
+++ b/calc/src/mechanics/gen12.ts
@@ -1,9 +1,9 @@
-import {Generation} from '../data/interface';
+import type {Generation} from '../data/interface';
 import {getItemBoostType} from '../items';
-import {RawDesc} from '../desc';
-import {Field} from '../field';
-import {Move} from '../move';
-import {Pokemon} from '../pokemon';
+import type {RawDesc} from '../desc';
+import type {Field} from '../field';
+import type {Move} from '../move';
+import type {Pokemon} from '../pokemon';
 import {Result} from '../result';
 import {computeFinalStats, getMoveEffectiveness, handleFixedDamageMoves} from './util';
 

--- a/calc/src/mechanics/gen3.ts
+++ b/calc/src/mechanics/gen3.ts
@@ -1,9 +1,9 @@
-import {Generation} from '../data/interface';
+import type {Generation} from '../data/interface';
 import {getItemBoostType} from '../items';
-import {RawDesc} from '../desc';
-import {Pokemon} from '../pokemon';
-import {Move} from '../move';
-import {Field} from '../field';
+import type {RawDesc} from '../desc';
+import type {Pokemon} from '../pokemon';
+import type {Move} from '../move';
+import type {Field} from '../field';
 import {Result} from '../result';
 import {
   getModifiedStat,

--- a/calc/src/mechanics/gen4.ts
+++ b/calc/src/mechanics/gen4.ts
@@ -1,9 +1,9 @@
-import {Generation, AbilityName} from '../data/interface';
+import type {Generation, AbilityName} from '../data/interface';
 import {getItemBoostType, getNaturalGift, getFlingPower, getBerryResistType} from '../items';
-import {RawDesc} from '../desc';
-import {Field} from '../field';
-import {Move} from '../move';
-import {Pokemon} from '../pokemon';
+import type {RawDesc} from '../desc';
+import type {Field} from '../field';
+import type {Move} from '../move';
+import type {Pokemon} from '../pokemon';
 import {Result} from '../result';
 import {
   getModifiedStat,

--- a/calc/src/mechanics/gen56.ts
+++ b/calc/src/mechanics/gen56.ts
@@ -1,4 +1,4 @@
-import {Generation, AbilityName} from '../data/interface';
+import type {Generation, AbilityName} from '../data/interface';
 import {toID} from '../util';
 import {
   getItemBoostType,
@@ -7,10 +7,10 @@ import {
   getBerryResistType,
   getTechnoBlast,
 } from '../items';
-import {RawDesc} from '../desc';
-import {Field} from '../field';
-import {Move} from '../move';
-import {Pokemon} from '../pokemon';
+import type {RawDesc} from '../desc';
+import type {Field} from '../field';
+import type {Move} from '../move';
+import type {Pokemon} from '../pokemon';
 import {Result} from '../result';
 import {
   chainMods,

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -1,4 +1,4 @@
-import {Generation, AbilityName, StatID, Terrain} from '../data/interface';
+import type {Generation, AbilityName, StatID, Terrain} from '../data/interface';
 import {toID} from '../util';
 import {
   getBerryResistType,
@@ -9,10 +9,10 @@ import {
   getTechnoBlast,
   SEED_BOOSTED_STAT,
 } from '../items';
-import {RawDesc} from '../desc';
-import {Field} from '../field';
-import {Move} from '../move';
-import {Pokemon} from '../pokemon';
+import type {RawDesc} from '../desc';
+import type {Field} from '../field';
+import type {Move} from '../move';
+import type {Pokemon} from '../pokemon';
 import {Result} from '../result';
 import {
   chainMods,

--- a/calc/src/mechanics/util.ts
+++ b/calc/src/mechanics/util.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Generation,
   ID,
   ItemName,
@@ -11,11 +11,11 @@ import {
   Weather,
 } from '../data/interface';
 import {toID} from '../util';
-import {Field, Side} from '../field';
-import {Move} from '../move';
-import {Pokemon} from '../pokemon';
+import type {Field, Side} from '../field';
+import type {Move} from '../move';
+import type {Pokemon} from '../pokemon';
 import {Stats} from '../stats';
-import {RawDesc} from '../desc';
+import type {RawDesc} from '../desc';
 
 const EV_ITEMS = [
   'Macho Brace',

--- a/calc/src/move.ts
+++ b/calc/src/move.ts
@@ -1,5 +1,5 @@
-import * as I from './data/interface';
-import {State} from './state';
+import type * as I from './data/interface';
+import type {State} from './state';
 import {toID, extend} from './util';
 
 const SPECIAL = ['Fire', 'Water', 'Grass', 'Electric', 'Ice', 'Psychic', 'Dark', 'Dragon'];

--- a/calc/src/pokemon.ts
+++ b/calc/src/pokemon.ts
@@ -1,7 +1,7 @@
-import * as I from './data/interface';
+import type * as I from './data/interface';
 import {Stats} from './stats';
 import {toID, extend, assignWithout} from './util';
-import {State} from './state';
+import type {State} from './state';
 
 const STATS = ['hp', 'atk', 'def', 'spa', 'spd', 'spe'] as I.StatID[];
 const SPC = new Set(['spc']);

--- a/calc/src/result.ts
+++ b/calc/src/result.ts
@@ -1,8 +1,8 @@
-import {RawDesc, display, displayMove, getRecovery, getRecoil, getKOChance} from './desc';
-import {Generation} from './data/interface';
-import {Field} from './field';
-import {Move} from './move';
-import {Pokemon} from './pokemon';
+import {type RawDesc, display, displayMove, getRecovery, getRecoil, getKOChance} from './desc';
+import type {Generation} from './data/interface';
+import type {Field} from './field';
+import type {Move} from './move';
+import type {Pokemon} from './pokemon';
 
 export type Damage = number | number[] | [number, number] | [number[], number[]];
 

--- a/calc/src/state.ts
+++ b/calc/src/state.ts
@@ -1,4 +1,4 @@
-import * as I from './data/interface';
+import type * as I from './data/interface';
 
 export namespace State {
   export interface Pokemon {

--- a/calc/src/stats.ts
+++ b/calc/src/stats.ts
@@ -1,4 +1,4 @@
-import {Natures, Generation, TypeName, StatID, StatsTable} from './data/interface';
+import type {Natures, Generation, TypeName, StatID, StatsTable} from './data/interface';
 import {toID} from './util';
 
 const RBY: Array<StatID | 'spc'> = ['hp', 'atk', 'def', 'spc', 'spe'];

--- a/calc/src/test/calc.test.ts
+++ b/calc/src/test/calc.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 
-import {AbilityName, Terrain, Weather} from '../data/interface';
+import type {AbilityName, Terrain, Weather} from '../data/interface';
 import {inGen, inGens, tests} from './helper';
 
 describe('calc', () => {

--- a/calc/src/test/data.test.ts
+++ b/calc/src/test/data.test.ts
@@ -1,5 +1,5 @@
 import {calculate, Pokemon, Move} from '../adaptable';
-import * as I from '../data/interface';
+import type * as I from '../data/interface';
 
 import * as calc from '../index';
 import {Dex} from '@pkmn/dex';

--- a/calc/src/test/gen.ts
+++ b/calc/src/test/gen.ts
@@ -1,5 +1,5 @@
-import * as I from '../data/interface';
-import * as D from '@pkmn/dex';
+import type * as I from '../data/interface';
+import type * as D from '@pkmn/dex';
 
 export function toID(s: string) {
   return ('' + s).toLowerCase().replace(/[^a-z0-9]+/g, '') as I.ID;

--- a/calc/src/test/helper.ts
+++ b/calc/src/test/helper.ts
@@ -1,8 +1,8 @@
 /* eslint-env jest */
 
-import * as I from '../data/interface';
-import {calculate, Pokemon, Move, Result} from '../index';
-import {State} from '../state';
+import type * as I from '../data/interface';
+import {type Result, calculate, Pokemon, Move} from '../index';
+import type {State} from '../state';
 import {Field, Side} from '../field';
 
 const calc = (gen: I.GenerationNum) => (

--- a/calc/src/test/pokemon.test.ts
+++ b/calc/src/test/pokemon.test.ts
@@ -1,5 +1,5 @@
 import {Pokemon} from '../index';
-import {StatID, MoveName} from '../data/interface';
+import type {StatID, MoveName} from '../data/interface';
 
 describe('Pokemon', () => {
   test('defaults', () => {

--- a/calc/src/test/stats.test.ts
+++ b/calc/src/test/stats.test.ts
@@ -1,5 +1,5 @@
 import {Generations} from '../data';
-import {GenerationNum, StatsTable, StatID} from '../data/interface';
+import type {GenerationNum, StatsTable, StatID} from '../data/interface';
 import {Stats} from '../stats';
 import {getModifiedStat} from '../mechanics/util';
 

--- a/calc/src/util.ts
+++ b/calc/src/util.ts
@@ -1,5 +1,5 @@
 /* eslint-disable eqeqeq, @typescript-eslint/unbound-method, @typescript-eslint/ban-types */
-import {ID} from './data/interface';
+import type {ID} from './data/interface';
 
 export function toID(text: any): ID {
   return ('' + text).toLowerCase().replace(/[^a-z0-9]+/g, '') as ID;


### PR DESCRIPTION
I'm mainly interested in getting this merged to eventually run `damage-calc` under bun (they apparently don't support importing types without doing this https://github.com/oven-sh/bun/issues/7384#issuecomment-1872459934)

The changes are mostly generated with the new eslint rule + `eslint --fix .` (with some manual fixes after)

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export
