### PR TITLE
Mold Breaker shouldn't remove abilities that don't affect direct damage

### DIFF
--- a/calc/src/mechanics/gen4.ts
+++ b/calc/src/mechanics/gen4.ts
@@ -66,6 +66,8 @@ export function calculateDPP(
     return result;
   }
 
+  const tempAbility = defender.ability;
+
   if (attacker.hasAbility('Mold Breaker')) {
     defender.ability = '' as AbilityName;
     desc.attackerAbility = attacker.ability;
@@ -196,6 +198,14 @@ export function calculateDPP(
   const attack = calculateAttackDPP(gen, attacker, defender, move, field, desc, isCritical);
 
   // #endregion
+
+  // Restores the defender's ability after disabling it for Mold Breaker purposes.
+  // This will make abilities like Rain Dish and Dry Skin work
+  // even when the attacker has Mold Breaker.
+  if (attacker.hasAbility('Mold Breaker')) {
+    defender.ability = tempAbility;
+  }
+
   // #region (Special) Defense
   const defense = calculateDefenseDPP(gen, attacker, defender, move, field, desc, isCritical);
 

--- a/calc/src/mechanics/gen56.ts
+++ b/calc/src/mechanics/gen56.ts
@@ -95,6 +95,8 @@ export function calculateBWXY(
     return result;
   }
 
+  const tempAbility = defender.ability;
+
   if (attacker.hasAbility('Mold Breaker', 'Teravolt', 'Turboblaze')) {
     defender.ability = '' as AbilityName;
     desc.attackerAbility = attacker.ability;
@@ -285,6 +287,14 @@ export function calculateBWXY(
   const attackStat = move.category === 'Special' ? 'spa' : 'atk';
 
   // #endregion
+
+  // Restores the defender's ability after disabling it for Mold Breaker purposes.
+  // This will make abilities like Rain Dish and Dry Skin work
+  // even when the attacker has Mold Breaker.
+  if (attacker.hasAbility('Mold Breaker', 'Teravolt', 'Turboblaze')) {
+    defender.ability = tempAbility;
+  }
+
   // #region (Special) Defense
 
   const defense = calculateDefenseBWXY(gen, attacker, defender, move, field, desc, isCritical);

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -169,8 +169,10 @@ export function calculateSMSSSV(
     'Searing Sunraze Smash',
     'Sunsteel Strike'
   );
-  if (!defenderIgnoresAbility && !defender.hasAbility('Poison Heal') &&
-    (attackerIgnoresAbility || moveIgnoresAbility)) {
+
+  const tempAbility = defender.ability;
+
+  if (!defenderIgnoresAbility && (attackerIgnoresAbility || moveIgnoresAbility)) {
     if (attackerIgnoresAbility) desc.attackerAbility = attacker.ability;
     if (defender.hasItem('Ability Shield')) {
       desc.defenderItem = defender.item;
@@ -555,6 +557,15 @@ export function calculateSMSSSV(
           ? 'spa'
           : 'atk';
   // #endregion
+
+  // Restores the defender's ability after disabling it for the purposes of
+  // Mold Breaker and other moves that ignore abilities.
+  // This will make abilities like Rain Dish and Quark Drive work
+  // even when the attacker has Mold Breaker.
+  if (attackerIgnoresAbility || moveIgnoresAbility) {
+    defender.ability = tempAbility;
+  }
+
   // #region (Special) Defense
 
   const defense = calculateDefenseSMSSSV(gen, attacker, defender, move, field, desc, isCritical);

--- a/calc/src/test/calc.test.ts
+++ b/calc/src/test/calc.test.ts
@@ -722,6 +722,32 @@ describe('calc', () => {
           'Lvl 90 Chansey Seismic Toss vs. Lvl 30 0 HP 0 IVs Mew: 90-90 (90 - 90%) -- guaranteed OHKO after sandstorm damage and burn damage'
         );
       });
+
+      inGens(4, 9, ({gen, calculate, Pokemon, Move, Field}) => {
+        test(`Mold Breaker does not disable abilities that don't affect direct damage (gen ${gen})`, () => {
+          const attacker = Pokemon('Rampardos', {
+            ability: 'Mold Breaker',
+          });
+
+          const defender = Pokemon('Blastoise', {
+            ability: 'Rain Dish',
+          });
+
+          const field = Field({
+            weather: 'Rain',
+          });
+
+          const move = Move('Stone Edge');
+
+          const result = calculate(attacker, defender, move, field);
+
+          expect(result.defender.ability).toBe('Rain Dish');
+
+          expect(result.desc()).toBe(
+            '0 Atk Mold Breaker Rampardos Stone Edge vs. 0 HP / 0 Def Blastoise: 168-198 (56.1 - 66.2%) -- guaranteed 2HKO after Rain Dish recovery'
+          );
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Fixes https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/post-10239710

Before:
0 SpA Mold Breaker Ampharos-Mega Dragon Pulse vs. 252 HP / 252+ SpD Iron Treads: 63-75 (16.4 - 19.5%) -- possible 8HKO
(Activate Electric Terrain)
0 SpA Mold Breaker Ampharos-Mega Dragon Pulse vs. 252 HP / 252+ SpD Iron Treads: 63-75 (16.4 - 19.5%) -- possible 8HKO

After:
0 SpA Mold Breaker Ampharos-Mega Dragon Pulse vs. 252 HP / 252+ SpD Iron Treads: 63-75 (16.4 - 19.5%) -- possible 8HKO
(Activate Electric Terrain)
0 SpA Mold Breaker Ampharos-Mega Dragon Pulse vs. 252 HP / 252+ SpD Quark Drive Iron Treads: 49-58 (12.7 - 15.1%) -- possibly the worst move ever

I think that if we used `@pkmn/data` and `@pkmn/dex`, then this code (as well as other pieces of code) can be cleaned up more easily, but that isn't taking into account any performance penalty and bundle size increase that may occur because of it.