### PR TITLE
Add support for moves breaking screens

### DIFF
--- a/calc/src/mechanics/gen3.ts
+++ b/calc/src/mechanics/gen3.ts
@@ -68,6 +68,9 @@ export function calculateADV(
     desc.weather = field.weather;
     desc.moveType = move.type;
     desc.moveBP = move.bp;
+  } else if (move.named('Brick Break')) {
+    field.defenderSide.isReflect = false;
+    field.defenderSide.isLightScreen = false;
   }
 
   const typeEffectivenessPrecedenceRules = [

--- a/calc/src/mechanics/gen4.ts
+++ b/calc/src/mechanics/gen4.ts
@@ -91,6 +91,9 @@ export function calculateDPP(
     desc.attackerItem = attacker.item;
     desc.moveBP = move.bp;
     desc.moveType = move.type;
+  } else if (move.named('Brick Break')) {
+    field.defenderSide.isReflect = false;
+    field.defenderSide.isLightScreen = false;
   }
 
   if (attacker.hasAbility('Normalize') && !move.named('Struggle')) {

--- a/calc/src/mechanics/gen56.ts
+++ b/calc/src/mechanics/gen56.ts
@@ -133,6 +133,9 @@ export function calculateBWXY(
         : field.hasTerrain('Misty') ? 'Fairy'
         : 'Normal';
     }
+  } else if (move.named('Brick Break')) {
+    field.defenderSide.isReflect = false;
+    field.defenderSide.isLightScreen = false;
   }
 
   let hasAteAbilityTypeChange = false;

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -273,6 +273,10 @@ export function calculateSMSSSV(
     } else if (attacker.named('Tauros-Paldea-Aqua')) {
       type = 'Water';
     }
+
+    field.defenderSide.isReflect = false;
+    field.defenderSide.isLightScreen = false;
+    field.defenderSide.isAuroraVeil = false;
   } else if (move.named('Ivy Cudgel')) {
     if (attacker.name.includes('Ogerpon-Cornerstone')) {
       type = 'Rock';
@@ -286,6 +290,10 @@ export function calculateSMSSSV(
   ) {
     move.target = 'allAdjacentFoes';
     type = 'Stellar';
+  } else if (move.named('Brick Break', 'Psychic Fangs')) {
+    field.defenderSide.isReflect = false;
+    field.defenderSide.isLightScreen = false;
+    field.defenderSide.isAuroraVeil = false;
   }
 
   let hasAteAbilityTypeChange = false;

--- a/calc/src/test/calc.test.ts
+++ b/calc/src/test/calc.test.ts
@@ -1452,5 +1452,64 @@ describe('calc', () => {
         });
       });
     });
+    describe('Some moves should break screens before doing damage', () => {
+      inGens(3, 9, ({calculate, Pokemon, Move, Field}) => {
+        test('Brick Break should break screens', () => {
+          const pokemon = Pokemon('Mew');
+
+          const brickBreak = Move('Brick Break');
+          const otherMove = Move('Vital Throw', {overrides: {basePower: 75}});
+
+          const field = Field({defenderSide: {isReflect: true}});
+
+          const brickBreakResult = calculate(pokemon, pokemon, brickBreak, field);
+          expect(brickBreakResult.field.defenderSide.isReflect).toBe(false);
+
+          const otherMoveResult = calculate(pokemon, pokemon, otherMove, field);
+          expect(otherMoveResult.field.defenderSide.isReflect).toBe(true);
+
+          expect(brickBreakResult.range()[0]).toBeGreaterThan(otherMoveResult.range()[0]);
+          expect(brickBreakResult.range()[1]).toBeGreaterThan(otherMoveResult.range()[1]);
+        });
+      });
+      inGens(7, 9, ({calculate, Pokemon, Move, Field}) => {
+        test('Psychic Fangs should break screens', () => {
+          const pokemon = Pokemon('Mew');
+
+          const psychicFangs = Move('Psychic Fangs');
+          const otherMove = Move('Zen Headbutt', {overrides: {basePower: 75}});
+
+          const field = Field({defenderSide: {isReflect: true}});
+
+          const psychicFangsResult = calculate(pokemon, pokemon, psychicFangs, field);
+          expect(psychicFangsResult.field.defenderSide.isReflect).toBe(false);
+
+          const otherMoveResult = calculate(pokemon, pokemon, otherMove, field);
+          expect(otherMoveResult.field.defenderSide.isReflect).toBe(true);
+
+          expect(psychicFangsResult.range()[0]).toBeGreaterThan(otherMoveResult.range()[0]);
+          expect(psychicFangsResult.range()[1]).toBeGreaterThan(otherMoveResult.range()[1]);
+        });
+      });
+      inGen(9, ({calculate, Pokemon, Move, Field}) => {
+        test('Raging Bull should break screens', () => {
+          const pokemon = Pokemon('Tauros-Paldea-Aqua');
+
+          const ragingBull = Move('Raging Bull');
+          const otherMove = Move('Waterfall', {overrides: {basePower: 90}});
+
+          const field = Field({defenderSide: {isReflect: true}});
+
+          const ragingBullResult = calculate(pokemon, pokemon, ragingBull, field);
+          expect(ragingBullResult.field.defenderSide.isReflect).toBe(false);
+
+          const otherMoveResult = calculate(pokemon, pokemon, otherMove, field);
+          expect(otherMoveResult.field.defenderSide.isReflect).toBe(true);
+
+          expect(ragingBullResult.range()[0]).toBeGreaterThan(otherMoveResult.range()[0]);
+          expect(ragingBullResult.range()[1]).toBeGreaterThan(otherMoveResult.range()[1]);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Fixes https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/post-10281815

In these examples, Zen Headbutt's Base Power will be increased to match that of Psychic Fangs.
Before:
`0 Atk Mew Zen Headbutt vs. 0 HP / 0 Def Mew through Reflect: 23-27 (6.7 - 7.9%) -- possibly the worst move ever`
`0 Atk Mew Psychic Fangs vs. 0 HP / 0 Def Mew through Reflect: 23-27 (6.7 - 7.9%) -- possibly the worst move ever`

After:
`0 Atk Mew Zen Headbutt vs. 0 HP / 0 Def Mew through Reflect: 23-27 (6.7 - 7.9%) -- possibly the worst move ever`
`0 Atk Mew Psychic Fangs vs. 0 HP / 0 Def Mew: 46-54 (13.4 - 15.8%) -- possible 7HKO`