### PR TITLE
Let Honkalculate work with Ubers sets

### DIFF
--- a/src/honkalculate.template.html
+++ b/src/honkalculate.template.html
@@ -91,7 +91,7 @@
             <input class="visually-hidden" type="checkbox" name="tier" id="RU" /><label class="btn btn-mid gen-specific g5 g6 g7 g8 g9" for="RU">RU</label>
             <input class="visually-hidden" type="checkbox" name="tier" id="UU" /><label class="btn btn-mid" for="UU">UU</label>
             <input class="visually-hidden" type="checkbox" name="tier" id="OU" /><label class="btn btn-mid" for="OU">OU</label>
-            <input class="visually-hidden" type="checkbox" name="tier" id="Uber" /><label class="btn btn-right" for="Uber">Uber</label>
+            <input class="visually-hidden" type="checkbox" name="tier" id="Ubers" /><label class="btn btn-right" for="Ubers">Ubers</label>
     </span>
     </div>
 


### PR DESCRIPTION
Currently, when "Uber" is highlighted in the Honkalculator and you attempt to Honkalculate, no Ubers sets show up. This PR fixes this issue by changing "Uber" to "Ubers."