### PR TITLE
Add Zacian-Crowned and Zamazenta-Crowned to knockoff resist checks

### DIFF
--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -1049,8 +1049,8 @@ export function calculateBPModsSMSSSV(
     (defender.named('Kyogre', 'Kyogre-Primal') && defenderItem === 'Blue Orb') ||
     (defender.name.includes('Silvally') && defenderItem.includes('Memory')) ||
     defenderItem.includes(' Z') ||
-    (defender.named('Zacian') && defenderItem === 'Rusted Sword') ||
-    (defender.named('Zamazenta') && defenderItem === 'Rusted Shield') ||
+    (defender.name.includes('Zacian') && defenderItem === 'Rusted Sword') ||
+    (defender.name.includes('Zamazenta') && defenderItem === 'Rusted Shield') ||
     (defender.name.includes('Ogerpon-Cornerstone') && defenderItem === 'Cornerstone Mask') ||
     (defender.name.includes('Ogerpon-Hearthflame') && defenderItem === 'Hearthflame Mask') ||
     (defender.name.includes('Ogerpon-Wellspring') && defenderItem === 'Wellspring Mask') ||

--- a/calc/src/test/calc.test.ts
+++ b/calc/src/test/calc.test.ts
@@ -496,6 +496,18 @@ describe('calc', () => {
       });
     });
 
+    inGens(8, 9, ({gen, calculate, Pokemon, Move}) => {
+      test('Knock Off vs. Zacian Crowned', () => {
+        const weavile = Pokemon('Weavile');
+        const zacian = Pokemon('Zacian-Crowned', {ability: 'Intrepid Sword', item: 'Rusted Sword'});
+        const knockoff = Move('Knock Off');
+        const result = calculate(weavile, zacian, knockoff);
+        expect(result.desc()).toBe(
+          '0 Atk Weavile Knock Off vs. 0 HP / 0 Def Zacian-Crowned: 36-43 (11 - 13.2%) -- possible 8HKO'
+        );
+      });
+    });
+
     inGens(5, 9, ({gen, calculate, Pokemon, Move}) => {
       test(`Multi-hit interaction with Multiscale (gen ${gen})`, () => {
         const result = calculate(


### PR DESCRIPTION
Existing code only checks for `Zacian` and `Zamazenta` causing knockoff to be boosted when it shouldn't be

### Live calc for Lokix Knockoff into Zacian-Crowned (gen9 randbats):
![image](https://github.com/user-attachments/assets/5692a02d-a2f7-4d4a-8fcb-de227118ec4c)

### Live P.S. damage dealt for the same Lokix Knockoff into Zacian-Crowned
![image](https://github.com/user-attachments/assets/234069db-69e6-4663-92ab-d3142db95076)
