### PR TITLE
Fix Poltergeist/Knock Off + Protosynthesis/Quark Drive interaction

### DIFF
--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -438,7 +438,7 @@ export function calculateSMSSSV(
       (move.named('Dream Eater') &&
         (!(defender.hasStatus('slp') || defender.hasAbility('Comatose')))) ||
       (move.named('Steel Roller') && !field.terrain) ||
-      (move.named('Poltergeist') && (!defender.item || isQPActive(defender, field)))
+      (move.named('Poltergeist') && (!defender.item || (isQPActive(defender, field) && defender.hasItem('Booster Energy'))))
   ) {
     return result;
   }
@@ -847,7 +847,7 @@ export function calculateBasePowerSMSSSV(
     break;
   case 'Acrobatics':
     basePower = move.bp * (attacker.hasItem('Flying Gem') ||
-        (!attacker.item || isQPActive(attacker, field)) ? 2 : 1);
+        (!attacker.item || (isQPActive(attacker, field) && attacker.hasItem('Booster Energy'))) ? 2 : 1);
     desc.moveBP = basePower;
     break;
   case 'Assurance':
@@ -1038,7 +1038,7 @@ export function calculateBPModsSMSSSV(
   const defenderItem = (defender.item && defender.item !== '')
     ? defender.item : defender.disabledItem;
   let resistedKnockOffDamage =
-    (!defenderItem || isQPActive(defender, field)) ||
+    (!defenderItem || (isQPActive(defender, field) && defenderItem === 'Booster Energy')) ||
     (defender.named('Dialga-Origin') && defenderItem === 'Adamant Crystal') ||
     (defender.named('Palkia-Origin') && defenderItem === 'Lustrous Globe') ||
     // Griseous Core for gen 9, Griseous Orb otherwise

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -438,7 +438,8 @@ export function calculateSMSSSV(
       (move.named('Dream Eater') &&
         (!(defender.hasStatus('slp') || defender.hasAbility('Comatose')))) ||
       (move.named('Steel Roller') && !field.terrain) ||
-      (move.named('Poltergeist') && (!defender.item || (isQPActive(defender, field) && defender.hasItem('Booster Energy'))))
+      (move.named('Poltergeist') &&
+        (!defender.item || (isQPActive(defender, field) && defender.hasItem('Booster Energy'))))
   ) {
     return result;
   }
@@ -847,7 +848,8 @@ export function calculateBasePowerSMSSSV(
     break;
   case 'Acrobatics':
     basePower = move.bp * (attacker.hasItem('Flying Gem') ||
-        (!attacker.item || (isQPActive(attacker, field) && attacker.hasItem('Booster Energy'))) ? 2 : 1);
+        (!attacker.item ||
+          (isQPActive(attacker, field) && attacker.hasItem('Booster Energy'))) ? 2 : 1);
     desc.moveBP = basePower;
     break;
   case 'Assurance':

--- a/calc/src/test/calc.test.ts
+++ b/calc/src/test/calc.test.ts
@@ -1436,6 +1436,34 @@ describe('calc', () => {
         testCase({ability: 'Simple'}, 2);
         testCase({ability: 'Contrary'}, -1);
       });
+      test('Activating Protosynthesis with sun should not affect damage of Poltergeist and Knock Off', () => {
+        const attacker = Pokemon('Smeargle');
+        const defender = Pokemon('Gouging Fire', {'ability': 'Protosynthesis', 'item': 'Blunder Policy'});
+        const field = Field({
+          weather: 'Sun',
+        });
+
+        const knockOff = calculate(attacker, defender, Move('Knock Off'), field);
+        expect(knockOff.move.bp).toBe(65);
+
+
+        const poltergeist = calculate(attacker, defender, Move('Poltergeist'), field);
+        expect(poltergeist.move.bp).toBe(110);
+      });
+      test('Activating Quark Drive with Electric Terrain should not affect damage of Poltergeist and Knock Off', () => {
+        const attacker = Pokemon('Smeargle');
+        const defender = Pokemon('Iron Valiant', {'ability': 'Quark Drive', 'item': 'Blunder Policy'});
+        const field = Field({
+          weather: 'Sun',
+        });
+
+        const knockOff = calculate(attacker, defender, Move('Knock Off'), field);
+        expect(knockOff.move.bp).toBe(65);
+
+
+        const poltergeist = calculate(attacker, defender, Move('Poltergeist'), field);
+        expect(poltergeist.move.bp).toBe(110);
+      });
       test('Revelation Dance should change type if Pokemon Terastallized', () => {
         const attacker = Pokemon('Oricorio-Pom-Pom');
         const defender = Pokemon('Sandaconda');


### PR DESCRIPTION
Fixes https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/page-41#post-10458221

Essentially, when Protosynthesis and Quark Drive are activated via sun and Electric Terrain, respectively. the damage of Poltergeist and Knock Off should not be reduced. This PR fixes that and adds tests for this behavior.