### PR TITLE
Make test regarding Knock Off and untriggered Quark/Proto actually test behavior

### DIFF
--- a/calc/src/test/calc.test.ts
+++ b/calc/src/test/calc.test.ts
@@ -1444,8 +1444,7 @@ describe('calc', () => {
         });
 
         const knockOff = calculate(attacker, defender, Move('Knock Off'), field);
-        expect(knockOff.move.bp).toBe(65);
-
+        expect(knockOff.rawDesc.moveBP).toBe(97.5);
 
         const poltergeist = calculate(attacker, defender, Move('Poltergeist'), field);
         expect(poltergeist.move.bp).toBe(110);
@@ -1458,8 +1457,7 @@ describe('calc', () => {
         });
 
         const knockOff = calculate(attacker, defender, Move('Knock Off'), field);
-        expect(knockOff.move.bp).toBe(65);
-
+        expect(knockOff.rawDesc.moveBP).toBe(97.5);
 
         const poltergeist = calculate(attacker, defender, Move('Poltergeist'), field);
         expect(poltergeist.move.bp).toBe(110);


### PR DESCRIPTION
The test, as written, passes, but it doesn't actually test the intended behavior which is that Knock Off should have its power boosted when used on a Pokemon with Protosynthesis in sun or Quark Drive in Electric Terrain.