### PR TITLE
Allow perfect accuracy for 3 hit multihit moves

### DIFF
--- a/calc/src/test/calc.test.ts
+++ b/calc/src/test/calc.test.ts
@@ -432,7 +432,7 @@ describe('calc', () => {
             [37, 37, 39, 39, 39, 40, 40, 40, 40, 42, 42, 42, 43, 43, 43, 45],
           ]);
           expect(result.desc()).toBe(
-            '152 Atk Parental Bond Kangaskhan-Mega Frustration vs. 252 HP / 152+ Def Amoonguss: 190-225 (43.9 - 52%) -- approx. 6.6% chance to 2HKO'
+            '152 Atk Parental Bond Kangaskhan-Mega Frustration vs. 252 HP / 152+ Def Amoonguss: 190-225 (43.9 - 52%) -- 6.6% chance to 2HKO'
           );
         }
 
@@ -506,7 +506,7 @@ describe('calc', () => {
           );
           expect(result.range()).toEqual([218, 258]);
           expect(result.desc()).toBe(
-            '+4 Persian Fury Swipes (2 hits) vs. Abra: 218-258 (86.1 - 101.9%) -- 2.7% chance to OHKO'
+            '+4 Persian Fury Swipes (2 hits) vs. Abra: 218-258 (86.1 - 101.9%) -- 2.9% chance to OHKO'
           );
         } else if (gen === 3) {
           const result = calculate(


### PR DESCRIPTION
- Follow up on previous PR, allows perfect accuracy for 3 hit moves (notably surging strikes)
- Only takes slightly longer (3644ms vs 3249ms for Honkalculate vs All) 