### PR TITLE
Add Rivalry to Gen 4 Calc

### DIFF
--- a/calc/src/mechanics/gen4.ts
+++ b/calc/src/mechanics/gen4.ts
@@ -488,10 +488,10 @@ export function calculateBPModsDPP(
 
   if (attacker.hasAbility('Rivalry') && ![attacker.gender, defender.gender].includes('N')) {
     if (attacker.gender === defender.gender) {
-      basePower = Math.floor(basePower * 1.25)
+      basePower = Math.floor(basePower * 1.25);
       desc.rivalry = 'buffed';
     } else {
-      basePower = Math.floor(basePower * .75)
+      basePower = Math.floor(basePower * 0.75);
       desc.rivalry = 'nerfed';
     }
     desc.attackerAbility = attacker.ability;


### PR DESCRIPTION
As referenced in https://github.com/smogon/damage-calc/issues/707, Rivalry was not implemented in the Gen 4 calculator, and the mechanics for this one are pretty clear (25% boost/reduction depending on the gender matchup). 