### PR TITLE
Fix importing of sets with ability As One

### DIFF
--- a/src/js/moveset_import.js
+++ b/src/js/moveset_import.js
@@ -284,7 +284,7 @@ function addSets(pokes, name) {
 		currentRow = rows[i].split(/[()@]/);
 		// Skip the current row if it contains the ability As One (Spectrier / Glastrier),
 		// so that it is not treated as another distinct set.
-		if(currentRow.length > 0 && currentRow[0].includes('As One')) continue;
+		if (currentRow.length > 0 && currentRow[0].includes('As One')) continue;
 		for (var j = 0; j < currentRow.length; j++) {
 			currentRow[j] = checkExeptions(currentRow[j].trim());
 			if (calc.SPECIES[9][currentRow[j].trim()] !== undefined) {
@@ -307,7 +307,7 @@ function addSets(pokes, name) {
 		}
 	}
 	if (addedpokes > 0) {
-		alert(`Successfully imported ${addedpokes} ${addedpokes === 1 ? "set" : "sets"}`);
+		alert("Successfully imported " + addedpokes + (addedpokes === 1 ? " set" : " sets"));
 		$(allPokemon("#importedSetsOptions")).css("display", "inline");
 	} else {
 		alert("No sets imported, please check your syntax and try again");


### PR DESCRIPTION
### Description
This PR fixes a bug where importing a set with the ability As One (Spectrier) or As One (Glastrier) caused the app to incorrectly treat the input as two separate Pokémon, both Calyrex-Shadow/Calyrex-Ice, and Spectrier/Glastrier.

### Related Issue
Resolves #711.