### PR TITLE
Fix importing bug with Nature

### DIFF
--- a/src/js/moveset_import.js
+++ b/src/js/moveset_import.js
@@ -158,7 +158,7 @@ function getStats(currentPoke, rows, offset) {
 		}
 
 		currentNature = rows[x] ? rows[x].trim().split(" ") : '';
-		if (currentNature[1] == "Nature") {
+		if (currentNature[1] == "Nature" && currentNature[0] != "-") {
 			currentPoke.nature = currentNature[0];
 		}
 	}


### PR DESCRIPTION
When parsing a line containing the string `"Nature"`, verify that it does not refer to a move rather than to the nature of the pokemon, by checking that it does not start with `-`.

https://github.com/smogon/damage-calc/pull/713/files#diff-4ebb8d140e717944501ec5782f7e51c1728e911c11da25b84d8c90ce0031f720R161

Resolves #668.