### PR TITLE
Fix importing of moves with trailing spaces

### DIFF
--- a/src/js/moveset_import.js
+++ b/src/js/moveset_import.js
@@ -181,7 +181,7 @@ function getMoves(currentPoke, rows, offset) {
 		if (rows[x]) {
 			if (rows[x][0] == "-") {
 				movesFound = true;
-				var move = rows[x].slice(2).replace(/[[\]]/g, '').trim().replace(/\s+/g, ' ');
+				var move = rows[x].slice(2).replace("[", "").replace("]", "").trim().replace(/\s+/g, " ");
 				moves.push(move);
 			} else {
 				if (movesFound == true) {


### PR DESCRIPTION
Resolves #715, by using the appropriate regular expressions to clean up the line containing the move.