### PR TITLE
Fix : IVs of 0 are read as 31 by correctHiddenPower

### DIFF
--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -973,7 +973,7 @@ function correctHiddenPower(pokemon) {
 	var maxed = true;
 	for (var i = 0; i <= LEGACY_STATS[9].length; i++) {
 		var s = LEGACY_STATS[9][i];
-		var iv = ivs[legacyStatToStat(s)] = (pokemon.ivs && pokemon.ivs[s]) || 31;
+		var iv = ivs[legacyStatToStat(s)] = (pokemon.ivs && typeof pokemon.ivs[s] !== "undefined") ? pokemon.ivs[s] : 31;
 		if (iv !== 31) maxed = false;
 	}
 


### PR DESCRIPTION
Addresses the issue seen in https://github.com/smogon/damage-calc/issues/663