### PR TITLE
Forms Toggle Ability Change Fix

### DIFF
--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -942,6 +942,12 @@ $(".forme").change(function () {
 	var isAltForme = $(this).val() !== pokemonName;
 	if (isAltForme && abilities.indexOf(altForme.abilities[0]) !== -1 && !greninjaSet) {
 		container.find(".ability").val(altForme.abilities[0]);
+	} else if (!isAltForme && abilities.indexOf(altForme.abilities[0]) !== -1 && !greninjaSet) {
+		if (chosenSet && chosenSet.ability) {
+			container.find(".ability").val(chosenSet.ability);
+		} else {
+			container.find(".ability").val(altForme.abilities[0]);
+		}
 	} else if (greninjaSet) {
 		$(this).parent().find(".ability");
 	} else if (chosenSet) {


### PR DESCRIPTION
Correct alt forms logic to ensure abilities change when toggling between multiple forms.

Currently the logic for changing between alternate and regular forms of pokemon will fail to re-update the ability when the form matches its original set.

Some examples can be seen when toggling between mega forms such as Mega Gardevoir or Mega Charizard in gen 6.
Gardevoir (OU Wallbreaker) : Ability = Trace. Swap to Mega Gardevoir : Ability = Pixelate. Swap back to Gardevoir : Ability = Pixelate (this should be trace)

Charizard forms will change when toggled but will fail when going back to the base form or the mega form depending on the set chosen. Charizard (OU Dragon Dance) will get stuck with tough claws when toggling back and forth while Charizard-Mega-X will get stuck with Blaze when going back and forth. The Y forms act in the same way.

In the end both issues are from the same root cause that has been fixed in this commit. 

I did find a separate issue with Mega sets pulling in the non-correct base set ability but this is a separate issue and should require a different commit in to fix which if I can find it I will intend to do so.

(Example Mega Gardevoir (OU Wallbreaker) has pixelate normally and when form shifting to Gardevoir it will show synchronize instead of trace as expected on the OU Wallbreaker set.)