### PR TITLE
White Herb Item Removal Fix in Create Pokemon

### DIFF
--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -1062,7 +1062,7 @@ function createPokemon(pokeInfo) {
 			level: set.level,
 			ability: set.ability,
 			abilityOn: true,
-			item: set.item && typeof set.item !== "undefined" && (set.item === "Eviolite" || set.item.indexOf("ite") < 0) ? set.item : "",
+			item: set.item && typeof set.item !== "undefined" && (set.item === "Eviolite" || set.item === "White Herb" || set.item.indexOf("ite") < 0) ? set.item : "",
 			nature: set.nature,
 			ivs: ivs,
 			evs: evs,


### PR DESCRIPTION
Adds a special case for white herb in the create pokemon logic to fix the bug shown in issue 726 : https://github.com/smogon/damage-calc/issues/726