### PR TITLE
Updated damage output description to include weather and terrain text

### DIFF
--- a/calc/src/desc.ts
+++ b/calc/src/desc.ts
@@ -1054,7 +1054,7 @@ function buildDescription(description: RawDesc, attacker: Pokemon, defender: Pok
   }
   output += description.defenderName;
   if (description.weather && description.terrain) {
-    // do nothing
+    output += ' in ' + description.weather + ' and ' + description.terrain + ' Terrain';
   } else if (description.weather) {
     output += ' in ' + description.weather;
   } else if (description.terrain) {


### PR DESCRIPTION
In response to : https://github.com/smogon/damage-calc/issues/289

Simple fix, this allows the weather and terrain to appear in the damage text for all relevant weather / terrain boosts, which happens to include the Sun + Electric Terrain combo as seen above.