### PR TITLE
fix result text wrap

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -504,8 +504,9 @@ th {
 
 /* header */
 .move-result-group {
+    display: flex;
     min-width: 50em;
-    margin: 1em 0 11.5em;
+    margin-top: 1em;
 }
 .move-result-subgroup {
     float: left;
@@ -515,7 +516,7 @@ th {
     margin-right: 1em;
 }
 .main-result-group {
-    margin: 2em 0 1em;
+    margin: 0.5em 0 1em;
 }
 .result-move-header {
     font-size: 0.8em;


### PR DESCRIPTION
Currently, the move-result-group is only designed to take a certain amount of space, and increasing the space it uses visually pushes other elements around without changing the actual area of move-result-group.

This can be best seen by setting multiple moves of p1 to 10Mil-Volt Tbolt (or any move that causes a newline). The output desc is offset to beneath p2's moves, and there is a dead spot in the newly-used space where it thinks you're clicking on the desc.

This commit changes move-result-group to a flex container, so it will always take up as much space as it needs and desc remains placed below it.