### PR TITLE
add smogonAnalysis check for Aegislash-Shield/Both

### DIFF
--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -595,7 +595,7 @@ $(".item").change(function () {
 
 function smogonAnalysis(pokemonName) {
 	var generation = ["rb", "gs", "rs", "dp", "bw", "xy", "sm", "ss", "sv"][gen - 1];
-	if (["Aegislash-Shield", "Aegislash-Both"].indexOf(pokemonName) + 1) { pokemonName = "Aegislash"; }
+	if (pokemonName === "Aegislash-Shield" || pokemonName === "Aegislash-Both") pokemonName = "Aegislash";
 	return "https://smogon.com/dex/" + generation + "/pokemon/" + pokemonName.toLowerCase() + "/";
 }
 


### PR DESCRIPTION
Fixes #339 by adding a simple check for Aegislash-Shield/Both in the smogonAnalysis function. Also allows smogonAnalysis to update on forme change.
I looked through species.ts to see if there were any other alternate formes that needed parsing, but it seems to only be Aegislash.

Other errors that were mentioned in the issue were formes not showing up and Necrozma having broken smogonAnalysis links. In the time since the issue was opened, all of those have been fixed through other means.