### PR TITLE
Bump actions and add npm caching to speed up ci build times

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,13 @@ jobs:
         node-version: [18.x]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
       uses: Zarel/setup-node@patch-1
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
     - run: npm install
     - run: npm run test
       env:
@@ -46,7 +48,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - run: npm install
     - name: Build
       run: node build
@@ -55,7 +57,7 @@ jobs:
       with:
         # Upload entire repository
         path: 'dist'
-    - uses: actions/configure-pages@v5
+    - uses: actions/configure-pages@v6
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@v4

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -10,19 +10,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         path: damagecalc
+    
+    - name: Setup Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: 24.x
+        cache: 'npm'
+        cache-dependency-path: './damagecalc/package-lock.json'
+
     - name: Fetch sets
       run: |-
         cd damagecalc
-        npm install
+        npm ci
         npm run compile
         cd import
-        npm install
+        npm ci
         npm run compile
         cd ..
         node import/dist/set-import.js src/js/data/sets/
+
     - name: Commit and push if it changed
       run: |-
         cd damagecalc


### PR DESCRIPTION
This update ensures long-term support  by moving to Node 24.x and optimizes build speed using npm caching and npm ci.