### PR TITLE
#755 : Blank Sets clear moves in gens 1-2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "damagecalc",
+  "name": "damage-calc",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -728,7 +728,7 @@ $(".set-selector").change(function () {
 				pokeObj.find("." + LEGACY_STATS[gen][i] + " .dvs").val(15);
 			}
 			pokeObj.find(".nature").val("Hardy");
-			setSelectValueIfValid(abilityObj, pokemon.abilities[0], "");
+			setSelectValueIfValid(abilityObj, gen >= 3 ? pokemon.abilities[0] : "", "");
 			if (startsWith(pokemonName, "Ogerpon-") && !startsWith(pokemonName, "Ogerpon-Teal")) {
 				itemObj.val(pokemonName.split("-")[1] + " Mask");
 			} else {

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -728,7 +728,7 @@ $(".set-selector").change(function () {
 				pokeObj.find("." + LEGACY_STATS[gen][i] + " .dvs").val(15);
 			}
 			pokeObj.find(".nature").val("Hardy");
-			setSelectValueIfValid(abilityObj, gen >= 3 ? pokemon.abilities[0] : "", "");
+			setSelectValueIfValid(abilityObj, pokemon.abilities && pokemon.abilities[0], "");
 			if (startsWith(pokemonName, "Ogerpon-") && !startsWith(pokemonName, "Ogerpon-Teal")) {
 				itemObj.val(pokemonName.split("-")[1] + " Mask");
 			} else {


### PR DESCRIPTION
Bugfix for the following issue : https://github.com/smogon/damage-calc/issues/755

Fix makes it so sets in gen 1/2 don't try to check a null ability list on non randbats / registered sets (which the blank sets don't count as)