### PR TITLE
Champions: Fix exported info missing Nature

### DIFF
--- a/src/js/moveset_import.js
+++ b/src/js/moveset_import.js
@@ -40,8 +40,10 @@ function ExportPokemon(pokeInfo) {
 			finalText += serialize(EVs_Array, " / ");
 			finalText += "\n";
 		}
+		if (pokemon.nature) {
+			finalText += pokemon.nature + " Nature" + "\n";
+		}
 	}
-	if (pokemon.nature && gen > 2) finalText += pokemon.nature + " Nature" + "\n";
 	var IVs_Array = [];
 	for (var stat in pokemon.ivs) {
 		var iv = pokemon.ivs[stat] ? pokemon.ivs[stat] : 0;


### PR DESCRIPTION
Hi! I noticed that exporting sets from the Champions calculator didn't include the Pokemon's nature, so here's a quick and small PR to fix that.