### PR TITLE
bugfix champions.html and add to template/cachebuster list

### DIFF
--- a/build
+++ b/build
@@ -67,6 +67,7 @@ if (process.argv[2] !== 'view') {
 
 cpdir('src', 'dist');
 cpdir('calc/dist', 'dist/calc');
+makeCachebuster('src/champions.html', 'dist/champions.html');
 makeCachebuster('src/honkalculate.html', 'dist/honkalculate.html');
 makeCachebuster('src/index.html', 'dist/index.html');
 makeCachebuster('src/randoms.html', 'dist/randoms.html');

--- a/src/champions.html
+++ b/src/champions.html
@@ -442,7 +442,7 @@
                 <select class="move-selector calc-trigger small-select"></select>
                 <input class="move-bp calc-trigger" value="50" inputmode="decimal" />
                 <select class="move-type calc-trigger"></select>
-                <select class="move-cat calc-trigger>
+                <select class="move-cat calc-trigger">
                     <option value="Physical">Physical</option>
                     <option value="Special">Special</option>
                 </select>
@@ -514,7 +514,7 @@
                 <select class="move-selector calc-trigger small-select"></select>
                 <input class="move-bp calc-trigger" value="0" inputmode="decimal" />
                 <select class="move-type calc-trigger"></select>
-                <select class="move-cat calc-trigger>
+                <select class="move-cat calc-trigger">
                     <option value="Physical">Physical</option>
                     <option value="Special">Special</option>
                 </select>


### PR DESCRIPTION
[These](https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/post-10972245) [posts](https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/post-10974967) brought to my attention that `champions.html` wasn't showing move category properly. This has been fixed, and `champions.html` added to the makeCachebuster list in `build` as mentioned in the Discord.

edit: [this](https://www.smogon.com/forums/threads/pok%C3%A9mon-showdown-damage-calculator.3593546/post-10956947) post also pointed it out