### PR TITLE
Fix Growth type in Champions

### DIFF
--- a/calc/src/data/moves.ts
+++ b/calc/src/data/moves.ts
@@ -5453,6 +5453,7 @@ const CHAMPIONS_PATCH: {[name: string]: DeepPartial<MoveData>} = {
   'Snap Trap': {type: 'Steel'},
   'Spirit Shackle': {bp: 90},
   'Trop Kick': {bp: 85},
+  'Growth': {type: 'Grass'},
 };
 
 const CHAMPIONS: {[name: string]: MoveData} = extend(


### PR DESCRIPTION
Growth in champions has changed to grass type move. I have updated the champions_patch to include the changes.
[https://www.serebii.net/pokemonchampions/updatedattacks.shtml](url)
