### PR TITLE
OM calc: Made primal weather be prioritized 

### DIFF
--- a/src/js/oms_controls.js
+++ b/src/js/oms_controls.js
@@ -206,8 +206,8 @@ function toggleMNM() {
 	// mnm CAN change abilities and field conditions, we want to reset it just in case
 	autosetWeather($("#p1 .ability").val(), 0);
 	autosetTerrain($("#p1 .ability").val(), 0);
-	autosetWeather($("#p2 .ability").val(), 0);
-	autosetTerrain($("#p2 .ability").val(), 0);
+	autosetWeather($("#p2 .ability").val(), 1);
+	autosetTerrain($("#p2 .ability").val(), 1);
 }
 
 var shouldUseTS = false;
@@ -343,12 +343,13 @@ $("#p1 .item").bind("keyup change", function () {
 
 $("#p2 .item").bind("keyup change", function () {
 	autoUpdateStats("#p2");
-	autosetWeather($("#p2 .ability").val(), 0);
+	autosetWeather($("#p2 .ability").val(), 1);
 });
 $(".om-trigger").prop("checked", false);
 $(".om-trigger").change();
 $(".ts-trigger").bind("change keyup", toggleTS);
 $(".mnm-trigger").bind("change keyup", toggleMNM);
+
 $(".scale-trigger").bind("change keyup", toggleScale);
 $(".gen").change(function () {
 	$.ajax({

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -336,12 +336,12 @@ $("input[name='weather']").change(function () {
 
 var lastManualWeather = "";
 var lastAutoWeather = ["", ""];
-// primal weather (higher priority) should not be cancelled by lower priority weather (such as sun) 
-var lastAutoWeatherPriority = [0,0]
+// primal weather (higher priority) should not be cancelled by lower priority weather (such as sun)
+var lastAutoWeatherPriority = [0, 0];
 function setPreviousWeather(i) {
 	var newWeather = lastAutoWeather[1 - i] !== "" ? lastAutoWeather[1 - i] : "";
 	$("input:radio[name='weather'][value='" + newWeather + "']").prop("checked", true);
-		
+
 }
 function autosetWeather(ability, i) {
 
@@ -357,23 +357,21 @@ function autosetWeather(ability, i) {
 	switch (ability) {
 	case "Drought":
 	case "Orichalcum Pulse":
-		
 		lastAutoWeather[i] = "Sun";
 		lastAutoWeatherPriority[i] = 0;
-		if (lastAutoWeatherPriority[1-i] == 1) {setPreviousWeather(i);break;}
+		if (lastAutoWeatherPriority[1 - i] == 1) {setPreviousWeather(i); break;}
 		$("#sun").prop("checked", true);
 		break;
 	case "Drizzle":
 		lastAutoWeather[i] = "Rain";
 		lastAutoWeatherPriority[i] = 0;
-		if (lastAutoWeatherPriority[1-i] == 1) {setPreviousWeather(i);break;}
+		if (lastAutoWeatherPriority[1 - i] == 1) {setPreviousWeather(i); break;}
 		$("#rain").prop("checked", true);
 		break;
 	case "Sand Stream":
-		
 		lastAutoWeather[i] = "Sand";
 		lastAutoWeatherPriority[i] = 0;
-		if (lastAutoWeatherPriority[1-i] == 1) {setPreviousWeather(i);break;}
+		if (lastAutoWeatherPriority[1 - i] == 1) {setPreviousWeather(i); break;}
 		$("#sand").prop("checked", true);
 		break;
 	case "Snow Warning":
@@ -386,8 +384,8 @@ function autosetWeather(ability, i) {
 			weatherElem = "#hail";
 		}
 		lastAutoWeatherPriority[i] = 0;
-		if (lastAutoWeatherPriority[1-i] == 1) {setPreviousWeather(i);break;}
-		$(weatherElem).prop("checked",true);
+		if (lastAutoWeatherPriority[1 - i] == 1) {setPreviousWeather(i); break;}
+		$(weatherElem).prop("checked", true);
 		break;
 	case "Desolate Land":
 		lastAutoWeather[i] = "Harsh Sunshine";

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -336,6 +336,13 @@ $("input[name='weather']").change(function () {
 
 var lastManualWeather = "";
 var lastAutoWeather = ["", ""];
+// primal weather (higher priority) should not be cancelled by lower priority weather (such as sun) 
+var lastAutoWeatherPriority = [0,0]
+function setPreviousWeather(i) {
+	var newWeather = lastAutoWeather[1 - i] !== "" ? lastAutoWeather[1 - i] : "";
+	$("input:radio[name='weather'][value='" + newWeather + "']").prop("checked", true);
+		
+}
 function autosetWeather(ability, i) {
 
 	if ($('.locked-weather').length) {
@@ -350,42 +357,57 @@ function autosetWeather(ability, i) {
 	switch (ability) {
 	case "Drought":
 	case "Orichalcum Pulse":
+		
 		lastAutoWeather[i] = "Sun";
+		lastAutoWeatherPriority[i] = 0;
+		if (lastAutoWeatherPriority[1-i] == 1) {setPreviousWeather(i);break;}
 		$("#sun").prop("checked", true);
 		break;
 	case "Drizzle":
 		lastAutoWeather[i] = "Rain";
+		lastAutoWeatherPriority[i] = 0;
+		if (lastAutoWeatherPriority[1-i] == 1) {setPreviousWeather(i);break;}
 		$("#rain").prop("checked", true);
 		break;
 	case "Sand Stream":
+		
 		lastAutoWeather[i] = "Sand";
+		lastAutoWeatherPriority[i] = 0;
+		if (lastAutoWeatherPriority[1-i] == 1) {setPreviousWeather(i);break;}
 		$("#sand").prop("checked", true);
 		break;
 	case "Snow Warning":
+		var weatherElem;
 		if (gen >= 9) {
 			lastAutoWeather[i] = "Snow";
-			$("#snow").prop("checked", true);
+			weatherElem = "#snow";
 		} else {
 			lastAutoWeather[i] = "Hail";
-			$("#hail").prop("checked", true);
+			weatherElem = "#hail";
 		}
+		lastAutoWeatherPriority[i] = 0;
+		if (lastAutoWeatherPriority[1-i] == 1) {setPreviousWeather(i);break;}
+		$(weatherElem).prop("checked",true);
 		break;
 	case "Desolate Land":
 		lastAutoWeather[i] = "Harsh Sunshine";
+		lastAutoWeatherPriority[i] = 1;
 		$("#harsh-sunshine").prop("checked", true);
 		break;
 	case "Primordial Sea":
 		lastAutoWeather[i] = "Heavy Rain";
+		lastAutoWeatherPriority[i] = 1;
 		$("#heavy-rain").prop("checked", true);
 		break;
 	case "Delta Stream":
 		lastAutoWeather[i] = "Strong Winds";
+		lastAutoWeatherPriority[i] = 1;
 		$("#strong-winds").prop("checked", true);
 		break;
 	default:
 		lastAutoWeather[i] = "";
-		var newWeather = lastAutoWeather[1 - i] !== "" ? lastAutoWeather[1 - i] : "";
-		$("input:radio[name='weather'][value='" + newWeather + "']").prop("checked", true);
+		lastAutoWeatherPriority[i] = 0;
+		setPreviousWeather(i);
 		break;
 	}
 }


### PR DESCRIPTION
Made it so primal weather cannot be overwritten by normal weather to better reflect the state of the battle, mainly relevant in MnM where Primordial Sea and Desolate Land are real