### PR TITLE
Toggle Analytic with a checkbox

### DIFF
--- a/calc/src/mechanics/champions.ts
+++ b/calc/src/mechanics/champions.ts
@@ -739,7 +739,7 @@ export function calculateBPModsChampions(
     (attacker.hasAbility('Sand Force') &&
       field.hasWeather('Sand') && move.hasType('Rock', 'Ground', 'Steel')) ||
     (attacker.hasAbility('Analytic') &&
-      (turnOrder !== 'first' || field.defenderSide.isSwitching === 'out')) ||
+      (turnOrder !== 'first' || field.defenderSide.isSwitching === 'out' || attacker.abilityOn)) ||
     (attacker.hasAbility('Tough Claws') && move.flags.contact))
   ) {
     bpMods.push(5325);

--- a/calc/src/mechanics/gen56.ts
+++ b/calc/src/mechanics/gen56.ts
@@ -656,7 +656,7 @@ export function calculateBPModsBWXY(
   ) {
     bpMods.push(6144);
     desc.attackerAbility = attacker.ability;
-  } else if (attacker.hasAbility('Analytic') && turnOrder !== 'first') {
+  } else if (attacker.hasAbility('Analytic') && turnOrder !== 'first' || attacker.abilityOn) {
     bpMods.push(5325);
     desc.attackerAbility = attacker.ability;
   } else if (

--- a/calc/src/mechanics/gen789.ts
+++ b/calc/src/mechanics/gen789.ts
@@ -1203,7 +1203,7 @@ export function calculateBPModsSMSSSV(
     (attacker.hasAbility('Sand Force') &&
       field.hasWeather('Sand') && move.hasType('Rock', 'Ground', 'Steel')) ||
     (attacker.hasAbility('Analytic') &&
-      (turnOrder !== 'first' || field.defenderSide.isSwitching === 'out')) ||
+      (turnOrder !== 'first' || field.defenderSide.isSwitching === 'out') || attacker.abilityOn) ||
     (attacker.hasAbility('Tough Claws') && move.flags.contact) ||
     (attacker.hasAbility('Punk Rock') && move.flags.sound)
   ) {

--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -272,7 +272,7 @@ $(".ability").bind("keyup change", function () {
 		$(this).closest(".poke-info").find(moveSelector).find(".move-hits").val(moveHits);
 	}
 
-	var TOGGLE_ABILITIES = ['Flash Fire', 'Intimidate', 'Minus', 'Plus', 'Slow Start', 'Unburden', 'Stakeout', 'Teraform Zero'];
+	var TOGGLE_ABILITIES = ['Flash Fire', 'Intimidate', 'Minus', 'Plus', 'Slow Start', 'Unburden', 'Analytic', 'Stakeout', 'Teraform Zero'];
 
 	if (TOGGLE_ABILITIES.indexOf(ability) >= 0) {
 		$(this).closest(".poke-info").find(".abilityToggle").show();


### PR DESCRIPTION
Fulfills https://www.smogon.com/forums/threads/add-a-checkmark-to-analytic-in-the-calculator.3774198/

Does not remove the existing ways to activate Analytic (being slower, switching out)