### PR TITLE
Fix willCrit auto-check when Pokemon is Dynamaxed

### DIFF
--- a/src/js/shared_controls.js
+++ b/src/js/shared_controls.js
@@ -499,7 +499,8 @@ $(".move-selector").change(function () {
 	$(this).attr('data-prev', moveName);
 	moveGroupObj.children(".move-type").val(move.type);
 	moveGroupObj.children(".move-cat").val(move.category);
-	moveGroupObj.children(".move-crit").prop("checked", move.willCrit === true);
+	var isDynamaxed = $(this).closest(".poke-info").find(".max").prop("checked");
+	moveGroupObj.children(".move-crit").prop("checked", !isDynamaxed && move.willCrit === true);
 
 	var stat = move.category === 'Special' ? 'spa' : 'atk';
 	if (Array.isArray(move.multihit) || (!isNaN(move.multihit) && move.multiaccuracy)) {


### PR DESCRIPTION
## Summary
- Fixes #803
- When a move that always crits (Frost Breath, Wicked Blow, etc.) is selected, the crit checkbox auto-checks based on `move.willCrit`. However, when a Pokémon is Dynamaxed these moves become generic Max moves and lose their guaranteed crit status, so the checkbox should not auto-check.

**Before:**
```js
moveGroupObj.children(".move-crit").prop("checked", move.willCrit === true);
```

**After:**
```js
var isDynamaxed = $(this).closest(".poke-info").find(".max").prop("checked");
moveGroupObj.children(".move-crit").prop("checked", !isDynamaxed && move.willCrit === true);
```

## Test plan
- [ ] Select a Gen 8 Pokémon, enable Dynamax, then select Frost Breath or Wicked Blow — Crit button should NOT auto-check
- [ ] Without Dynamax, select Frost Breath — Crit button should still auto-check as before